### PR TITLE
Rebalancing Cacodemon

### DIFF
--- a/lua/variables_pvp.lua
+++ b/lua/variables_pvp.lua
@@ -7,8 +7,19 @@ SKULL_ADDON_HEALTH                       = 30
 SKULL_INITIAL_DAMAGE                     = 7
 SKULL_ADDON_DAMAGE                       = 3
 SKULL_SEARCH_TIMEOUT                     = 75
-CACODEMON_INITIAL_DAMAGE                 = 70
-CACODEMON_ADDON_DAMAGE                   = 14
+-- Cacodemon
+CACODEMON_INITIAL_DAMAGE                 = 75
+CACODEMON_ADDON_DAMAGE                   = 7
+CACODEMON_SKULL_INITIAL_AMMO             = 2
+CACODEMON_SKULL_ADDON_AMMO               = 1
+CACODEMON_SKULL_START_AMMO               = 2
+CACODEMON_REGEN_FRAMES                   = 200
+CACODEMON_REGEN_DELAY                    = 5
+CACODEMON_INITIAL_RADIUS                 = 75
+CACODEMON_ADDON_RADIUS                   = 2.5
+CACODEMON_SKULL_SPEED                    = 750
+CACODEMON_ADDON_BURN                     = 1
+--
 MAX_PIPES                                = 5
 P_TANK_PUNCH_RADIUS                      = 170
 SPIKEBALL_INITIAL_HEALTH                 = 80


### PR DESCRIPTION
The goal with these changes is to reduce how much the Cacodemon outpaces the Rocket Launcher in damage. I also want to drive Cacodemons to value their life more by reducing the amount they get from regen, and by actually getting them to run out of ammo from time to time when spamming. 

Testing required.

- Increased base damage from 70 to 75
- Reduced addon damage from 14 to 7
- Reduced overall ammo so they can actually run out
- Reduced regen frames from 300 to 200
- Increased regen delay from 2 to 5 seconds
- Reduced initial radius from 125 to 75
- Reduced addon radius from 4 to 2.5