### PR TITLE
Fix massive tank rocket damage and some regen

### DIFF
--- a/lua/variables_pvm.lua
+++ b/lua/variables_pvm.lua
@@ -27,7 +27,9 @@ SENTRY_ADDON_BULLETDAMAGE                = 2
 -- POLTERGEIST
 -- TANK
 P_TANK_PUNCH_RADIUS                      = 224
-P_TANK_ROCKET_ADDON_DMG                  = 55
+P_TANK_ROCKET_ADDON_DMG                  = 6.5
+P_TANK_AMMOREGEN_DELAY                   = 3
+P_TANK_REGEN_DELAY                       = 40
 
 -- CACODEMON
 CACODEMON_INITIAL_DAMAGE                 = 100

--- a/lua/variables_pvm.lua
+++ b/lua/variables_pvm.lua
@@ -1,5 +1,8 @@
 -- pvm variables
 q2.print("Lua: Running pvm variables\n")
+
+-- NECROMANCER
+-- HELLSPAWN
 SKULL_MOVE_HORIZONTAL_SPEED              = 30
 SKULL_MOVE_VERTICAL_SPEED                = 30
 SKULL_INITIAL_HEALTH                     = 150
@@ -7,13 +10,25 @@ SKULL_ADDON_HEALTH                       = 40
 SKULL_INITIAL_DAMAGE                     = 10
 SKULL_ADDON_DAMAGE                       = 4
 SKULL_SEARCH_TIMEOUT                     = 100
-CACODEMON_INITIAL_DAMAGE                 = 100
-CACODEMON_ADDON_DAMAGE                   = 20
+
+-- SOLDIER
 MAX_PIPES                                = 12
-P_TANK_PUNCH_RADIUS                      = 224
 SPIKEBALL_INITIAL_HEALTH                 = 200
 SPIKEBALL_ADDON_HEALTH                   = 30
 SPIKEBALL_INITIAL_DAMAGE                 = 100
 SPIKEBALL_ADDON_DAMAGE                   = 50
+
+-- SHAMAN
 FIRETOTEM_DAMAGE_MULT                    = 6
+
+-- ENGINEER
 SENTRY_ADDON_BULLETDAMAGE                = 2
+
+-- POLTERGEIST
+-- TANK
+P_TANK_PUNCH_RADIUS                      = 224
+P_TANK_ROCKET_ADDON_DMG                  = 55
+
+-- CACODEMON
+CACODEMON_INITIAL_DAMAGE                 = 100
+CACODEMON_ADDON_DAMAGE                   = 20

--- a/lua/variables_pvp.lua
+++ b/lua/variables_pvp.lua
@@ -7,7 +7,9 @@ SKULL_ADDON_HEALTH                       = 30
 SKULL_INITIAL_DAMAGE                     = 7
 SKULL_ADDON_DAMAGE                       = 3
 SKULL_SEARCH_TIMEOUT                     = 75
--- Cacodemon
+
+-- POLTERGEIST
+-- CACODEMON
 CACODEMON_INITIAL_DAMAGE                 = 75
 CACODEMON_ADDON_DAMAGE                   = 7
 CACODEMON_SKULL_INITIAL_AMMO             = 2
@@ -19,12 +21,20 @@ CACODEMON_INITIAL_RADIUS                 = 75
 CACODEMON_ADDON_RADIUS                   = 2.5
 CACODEMON_SKULL_SPEED                    = 750
 CACODEMON_ADDON_BURN                     = 1
---
-MAX_PIPES                                = 5
+
+-- TANK
 P_TANK_PUNCH_RADIUS                      = 170
+P_TANK_ROCKET_ADDON_DMG                  = 4.5
+
+-- SOLDIER
+MAX_PIPES                                = 5
 SPIKEBALL_INITIAL_HEALTH                 = 80
 SPIKEBALL_ADDON_HEALTH                   = 10
 SPIKEBALL_INITIAL_DAMAGE                 = 40
 SPIKEBALL_ADDON_DAMAGE                   = 10
+
+-- SHAMAN
 FIRETOTEM_DAMAGE_MULT                    = 4
+
+-- ENGINEER
 SENTRY_ADDON_BULLETDAMAGE                = 1

--- a/lua/variables_pvp.lua
+++ b/lua/variables_pvp.lua
@@ -24,7 +24,9 @@ CACODEMON_ADDON_BURN                     = 1
 
 -- TANK
 P_TANK_PUNCH_RADIUS                      = 170
-P_TANK_ROCKET_ADDON_DMG                  = 4.5
+P_TANK_ROCKET_ADDON_DMG                  = 5.5
+P_TANK_AMMOREGEN_DELAY                   = 3
+P_TANK_REGEN_DELAY                       = 40
 
 -- SOLDIER
 MAX_PIPES                                = 5

--- a/src/server/v_luasettings.c
+++ b/src/server/v_luasettings.c
@@ -112,7 +112,7 @@ int q2lua_getplayercount(lua_State *L)
 	return 1;
 }
 
-int q2lua_get_mapname(lua_State *L) 
+int q2lua_get_mapname(lua_State *L)
 {
 	lua_pushstring(L, level.mapname);
 	return 1;
@@ -1996,7 +1996,7 @@ void Lua_LoadVariables()
 	P_TANK_BLASTER_INITIAL_SPD = vrx_lua_get_variable("P_TANK_BLASTER_INITIAL_SPD", 1500);
 	P_TANK_BLASTER_ADDON_SPD = vrx_lua_get_variable("P_TANK_BLASTER_ADDON_SPD", 55);
 	P_TANK_ROCKET_INITIAL_DMG = vrx_lua_get_variable("P_TANK_ROCKET_INITIAL_DMG", 150);
-	P_TANK_ROCKET_ADDON_DMG = vrx_lua_get_variable("P_TANK_ROCKET_ADDON_DMG", 35);
+	P_TANK_ROCKET_ADDON_DMG = vrx_lua_get_variable("P_TANK_ROCKET_ADDON_DMG", 2.5);
 	P_TANK_ROCKET_INITIAL_SPD = vrx_lua_get_variable("P_TANK_ROCKET_INITIAL_SPD", 650);
 	P_TANK_ROCKET_ADDON_SPD = vrx_lua_get_variable("P_TANK_ROCKET_ADDON_SPD", 40);
 	P_TANK_BULLET_INITIAL_DMG = vrx_lua_get_variable("P_TANK_BULLET_INITIAL_DMG", 35);


### PR DESCRIPTION
I understand that we are only using LUA values to override defaults, but still wanted to fix the default in any case.

This resolves the MASSIVE damage that the tank was doing with the rocket. 

Also I'm working on a separate branch a workaround the Resistances, since the damage is going straight up to the TANK.

I was able to fix some but seems like the issue goes a bit deeper than that so it would be nice to check that out with more time.