### PR TITLE
fix how haste works. 10% improvement/level

### DIFF
--- a/src/characters/v_abilitylist.c
+++ b/src/characters/v_abilitylist.c
@@ -267,7 +267,7 @@ int getHardMax(int index, qboolean general, int class) {
 
             
         case HASTE:
-            return 5;
+            return 10;
 
         // Special cases for the non-general ability mode.
         // Falls through to the default case...

--- a/src/combat/weapons/p_weapon.c
+++ b/src/combat/weapons/p_weapon.c
@@ -769,9 +769,10 @@ void Weapon_Generic(
         // time when to fire next shot
         float haste_wait = 1;
         float haste_tech = 1;
-        float haste_skill = 1;
+        float haste_skill = INFINITY; // "never"
 
-        haste_skill = 1.0f / ent->myskills.abilities[HASTE].current_level;
+        if (ent->myskills.abilities[HASTE].current_level >= 1)
+            haste_skill = 1.0f / ent->myskills.abilities[HASTE].current_level;
 
         // haste tech
         if (ent->client->pers.inventory[haste_index]) {

--- a/src/combat/weapons/p_weapon.c
+++ b/src/combat/weapons/p_weapon.c
@@ -767,35 +767,27 @@ void Weapon_Generic(
 
     if (!ent->myskills.abilities[HASTE].disable || ent->client->pers.inventory[haste_index]) {
         // time when to fire next shot
-        float haste_wait;
+        float haste_wait = 1;
+        float haste_tech = 1;
+        float haste_skill = 1;
 
-        if (ent->myskills.abilities[HASTE].current_level <= 1)
-            haste_wait = 0.5; // 17% improvement (1/1.2)
-        else if (ent->myskills.abilities[HASTE].current_level <= 2)
-            haste_wait = 0.44; // 20% improvement (1/1.25)
-        else if (ent->myskills.abilities[HASTE].current_level <= 3)
-            haste_wait = 0.33; // 25% improvement (1/1.333)
-        else if (ent->myskills.abilities[HASTE].current_level <= 4)
-            haste_wait = 0.2; // 33% improvement (1/1.5)
-        else
-            haste_wait = 0.11; // 50% improvement (1/2)
+        haste_skill = 1.0f / ent->myskills.abilities[HASTE].current_level;
 
         // haste tech
         if (ent->client->pers.inventory[haste_index]) {
-            if ((haste_wait > 0) && (ent->myskills.level <= 5))
-                haste_wait = 0; // 100% improvement (2x firing rate)
-            else if ((haste_wait > 1) && (ent->myskills.level <= 10))
-                haste_wait = 0.1;
-            else if ((haste_wait > 3))
-                haste_wait = 0.3;
+			haste_tech = 0.1; // 100% improvement (2x firing rate)
         }
+
+        haste_wait = min(haste_tech, haste_skill);
+        if (haste_wait <= 0) // safeguard lol
+            return;
 
         // if enough frames have passed by, then call the weapon func
         // an additional time
-        if (ent->haste_time >= haste_wait) {
+        while (ent->haste_time >= haste_wait) {
             Weapon_Generic2(ent, FRAME_ACTIVATE_LAST, FRAME_FIRE_LAST,
                             FRAME_IDLE_LAST, FRAME_DEACTIVATE_LAST, pause_frames, fire_frames, fire);
-            ent->haste_time = 0;
+            ent->haste_time -= haste_wait;
         }
         ent->haste_time += FRAMETIME;
     }


### PR DESCRIPTION
Improve haste behaviour so improvement is a consistent 10% per level. Scales to level 10 and beyond, and has easy to understand behaviour with the haste tech: take the better haste, and do not stack them. Also allows Weapon_Generic2 to be triggered more than twice per server frame by haste.