### PR TITLE
restore grenades detonating after death

### DIFF
--- a/src/combat/common/v_misc.c
+++ b/src/combat/common/v_misc.c
@@ -451,9 +451,6 @@ void vrx_remove_player_summonables(edict_t *self) {
             continue;
         }
 
-
-        
-#ifdef REMOVE_PROJECTILES_AFTER_DEATH // az: now commented out...
         // remove grenades
         if ((from->owner) && (from->owner == self)
             && !Q_stricmp(from->classname, "grenade")) {
@@ -467,7 +464,6 @@ void vrx_remove_player_summonables(edict_t *self) {
             && !Q_stricmp(from->classname, "bolt")) {
                 G_FreeEdict(from);
         }
-#endif
 
         // remove hammers
         cl_ent = G_GetClient(from);


### PR DESCRIPTION
Fixes #152. Looks like it was intentional at some point. REMOVE_PROJECTILES_AFTER_DEATH remains off though, but an exception was done here for detpipes/grenades.