### PR TITLE
Add pain states to monsters.

### DIFF
--- a/src/entities/drone/drone_brain.c
+++ b/src/entities/drone/drone_brain.c
@@ -229,7 +229,11 @@ mmove_t mybrain_move_pain_long = { FRAME_pain101, FRAME_pain118, mybrain_frames_
 
 void mybrain_pain(edict_t* self, edict_t* other, float kick, int damage)
 {
-	double rng = random();
+	const double rng = random();
+	const qboolean is_idling = self->monsterinfo.currentmove == &mybrain_move_idle ||
+		self->monsterinfo.currentmove == &mybrain_move_stand;
+	const qboolean moving_without_enemy = (self->monsterinfo.currentmove == &brain_move_walk1 && !self->enemy);
+
 	if (self->health < (self->max_health / 2))
 		self->s.skinnum = 1;
 
@@ -250,8 +254,7 @@ void mybrain_pain(edict_t* self, edict_t* other, float kick, int damage)
 
 	// if we're fidgeting, always go into pain state.
 	if (rng <= (1.0f - self->monsterinfo.pain_chance) &&
-		self->monsterinfo.currentmove != &mybrain_move_idle &&
-		self->monsterinfo.currentmove != &mybrain_move_stand)
+		!(is_idling || moving_without_enemy))
 		return;
 
 	if (random() < 0.5)
@@ -260,8 +263,7 @@ void mybrain_pain(edict_t* self, edict_t* other, float kick, int damage)
 		gi.sound(self, CHAN_VOICE, sound_pain2, 1, ATTN_NORM, 0);
 	}
 
-	if (self->monsterinfo.currentmove == &mybrain_move_idle ||
-		self->monsterinfo.currentmove == &mybrain_move_stand)
+	if (is_idling || moving_without_enemy)
 		self->monsterinfo.currentmove = &mybrain_move_pain_long;
 	else {
 		if (random() < 0.5)

--- a/src/entities/drone/drone_brain.c
+++ b/src/entities/drone/drone_brain.c
@@ -175,6 +175,102 @@ mframe_t mybrain_frames_defense [] =
 };
 mmove_t mybrain_move_defense = {FRAME_defens01, FRAME_defens08, mybrain_frames_defense, NULL};
 
+mframe_t mybrain_frames_pain_short1[] =
+{
+	ai_move, 0, NULL,
+	ai_move, 0, NULL,
+	ai_move, 0, NULL,
+	ai_move, 0, NULL,
+	ai_move, 0, NULL,
+	ai_move, 0, NULL,
+};
+mmove_t mybrain_move_pain_short1 = { FRAME_pain301, FRAME_pain306, mybrain_frames_pain_short1, mybrain_run };
+
+mframe_t mybrain_frames_pain_short2[] =
+{
+	ai_move, 0, NULL,
+	ai_move, 0, NULL,
+	ai_move, 0, NULL,
+	ai_move, 0, NULL,
+	ai_move, 0, NULL,
+	ai_move, 0, NULL,
+	ai_move, 0, NULL,
+	ai_move, 0, NULL,
+};
+mmove_t mybrain_move_pain_short2 = { FRAME_pain201, FRAME_pain208, mybrain_frames_pain_short2, mybrain_run };
+
+mframe_t mybrain_frames_pain_long[] =
+{
+	ai_move, 0, NULL,
+	ai_move, 0, NULL,
+	ai_move, 0, NULL,
+	ai_move, 0, NULL,
+
+	ai_move, 0, NULL,
+	ai_move, 0, NULL,
+	ai_move, 0, NULL,
+	ai_move, 0, NULL,
+
+	ai_move, 0, NULL,
+	ai_move, 0, NULL,
+	ai_move, 0, NULL,
+	ai_move, 0, NULL,
+
+	ai_move, 0, NULL,
+	ai_move, 0, NULL,
+	ai_move, 0, NULL,
+	ai_move, 0, NULL,
+
+	ai_move, 0, NULL,
+	ai_move, 0, NULL,
+};
+
+mmove_t mybrain_move_pain_long = { FRAME_pain101, FRAME_pain118, mybrain_frames_pain_long, mybrain_run };
+
+void mybrain_pain(edict_t* self, edict_t* other, float kick, int damage)
+{
+	double rng = random();
+	if (self->health < (self->max_health / 2))
+		self->s.skinnum = 1;
+
+	// we're already in a pain state
+	if (self->monsterinfo.currentmove == &mybrain_move_pain_long ||
+		self->monsterinfo.currentmove == &mybrain_move_pain_short1 ||
+		self->monsterinfo.currentmove == &mybrain_move_pain_short2 ||
+		self->monsterinfo.currentmove == &mybrain_move_defense)
+		return;
+
+	// monster players don't get pain state induced
+	if (G_GetClient(self))
+		return;
+
+	// no pain in invasion hard mode
+	if (invasion->value == 2)
+		return;
+
+	// if we're fidgeting, always go into pain state.
+	if (rng <= (1.0f - self->monsterinfo.pain_chance) &&
+		self->monsterinfo.currentmove != &mybrain_move_idle &&
+		self->monsterinfo.currentmove != &mybrain_move_stand)
+		return;
+
+	if (random() < 0.5)
+		gi.sound(self, CHAN_VOICE, sound_pain1, 1, ATTN_NORM, 0);
+	else {
+		gi.sound(self, CHAN_VOICE, sound_pain2, 1, ATTN_NORM, 0);
+	}
+
+	if (self->monsterinfo.currentmove == &mybrain_move_idle ||
+		self->monsterinfo.currentmove == &mybrain_move_stand)
+		self->monsterinfo.currentmove = &mybrain_move_pain_long;
+	else {
+		if (random() < 0.5)
+			self->monsterinfo.currentmove = &mybrain_move_pain_short1;
+		else
+			self->monsterinfo.currentmove = &mybrain_move_pain_short2;
+	}
+}
+
 //
 // DUCK
 //
@@ -362,6 +458,8 @@ void mybrain_jump (edict_t *self)
 void mybrain_dodge (edict_t *self, edict_t *attacker, vec3_t dir, int radius)
 {
 	if (random() > 0.9)
+		return;
+	if (!G_GetClient(self))
 		return;
 	if (level.time < self->monsterinfo.dodge_time)
 		return;
@@ -818,7 +916,8 @@ void init_drone_brain (edict_t *self)
 
 	self->item = FindItemByClassname("ammo_cells");
 
-//	self->pain = mybrain_pain;
+	self->monsterinfo.pain_chance = .2f;
+	self->pain = mybrain_pain;
 	self->die = mybrain_die;
 //	self->touch = mybrain_touch;
 

--- a/src/entities/drone/drone_hover.c
+++ b/src/entities/drone/drone_hover.c
@@ -486,13 +486,20 @@ void hover_pain (edict_t *self, edict_t *other, float kick, int damage)
 	if (self->health < (self->max_health / 2))
 		self->s.skinnum = 1;
 
-	if (level.time < self->pain_debounce_time)
+	// we're already in a pain state
+	if (self->monsterinfo.currentmove == &hover_move_pain1 ||
+		self->monsterinfo.currentmove == &hover_move_pain2 ||
+		self->monsterinfo.currentmove == &hover_move_pain3)
 		return;
 
-	self->pain_debounce_time = level.time + 3;
+	// monster players don't get pain state induced
+	if (G_GetClient(self))
+		return;
 
-	if (skill->value == 3)
-		return;		// no pain anims in nightmare
+	// stand animation always gets pain state
+	if (random() <= (1.0f - self->monsterinfo.pain_chance) &&
+		self->monsterinfo.currentmove == &hover_move_stand)
+		return;
 
 	if (damage <= 25)
 	{
@@ -616,6 +623,7 @@ void init_drone_hover (edict_t *self)
 	self->monsterinfo.attack = hover_attack;
 	self->monsterinfo.sight = hover_sight;
 	self->monsterinfo.idle = hover_search;
+	self->monsterinfo.pain_chance = 0.2f; 
 	//self->monsterinfo.search = hover_search;
 
 	gi.linkentity (self);

--- a/src/entities/drone/drone_infantry.c
+++ b/src/entities/drone/drone_infantry.c
@@ -252,6 +252,73 @@ void infantry_dead (edict_t *self)
 	M_PrepBodyRemoval(self);
 }
 
+mframe_t infantry_frames_pain1[] =
+{
+	ai_move, 0, NULL,
+	ai_move, 0, NULL,
+	ai_move, 0, NULL,
+	ai_move, 0, NULL,
+	ai_move, 0, NULL,
+	ai_move, 0, NULL,
+	ai_move, 0, NULL,
+	ai_move, 0, NULL,
+	ai_move, 0, NULL,
+	ai_move, 0, NULL,
+};
+mmove_t infantry_move_pain1 = { FRAME_pain101, FRAME_pain110, infantry_frames_pain1, infantry_run };
+
+mframe_t infantry_frames_pain2[] =
+{
+	ai_move, 0, NULL,
+	ai_move, 0, NULL,
+	ai_move, 0, NULL,
+	ai_move, 0, NULL,
+	ai_move, 0, NULL,
+	ai_move, 0, NULL,
+	ai_move, 0, NULL,
+	ai_move, 0, NULL,
+	ai_move, 0, NULL,
+	ai_move, 0, NULL,
+};
+mmove_t infantry_move_pain2 = { FRAME_pain201, FRAME_pain210, infantry_frames_pain2, infantry_run };
+
+void infantry_pain(edict_t* self, edict_t* other, float kick, int damage)
+{
+	double rng = random();
+	if (self->health < (self->max_health / 2))
+		self->s.skinnum = 1;
+
+	// we're already in a pain state
+	if (self->monsterinfo.currentmove == &infantry_move_pain2 ||
+		self->monsterinfo.currentmove == &infantry_move_pain1)
+		return;
+
+	// monster players don't get pain state induced
+	if (G_GetClient(self))
+		return;
+
+	// no pain in invasion hard mode
+	if (invasion->value == 2)
+		return;
+
+	// if we're fidgeting, always go into pain state.
+	if (rng <= (1.0f - self->monsterinfo.pain_chance) &&
+		self->monsterinfo.currentmove != &infantry_move_stand &&
+		self->monsterinfo.currentmove != &infantry_move_walk)
+		return;
+
+	if (random() < 0.5)
+		gi.sound(self, CHAN_VOICE, sound_pain1, 1, ATTN_NORM, 0);
+	else {
+		gi.sound(self, CHAN_VOICE, sound_pain2, 1, ATTN_NORM, 0);
+	}
+
+	if (random() < 0.5)
+		self->monsterinfo.currentmove = &infantry_move_pain1;
+	else
+		self->monsterinfo.currentmove = &infantry_move_pain2;
+}
+
 mframe_t infantry_frames_death1 [] =
 {
 	ai_move, -4, NULL,
@@ -607,7 +674,9 @@ void init_drone_infantry (edict_t *self)
 
 	self->item = FindItemByClassname("ammo_bullets");
 
-	//self->pain = infantry_pain;
+	// they're very sensitive to pain!
+	self->monsterinfo.pain_chance = 0.3f;
+	self->pain = infantry_pain;
 	self->die = infantry_die;
 
 	self->monsterinfo.stand = infantry_stand;

--- a/src/entities/drone/drone_medic.c
+++ b/src/entities/drone/drone_medic.c
@@ -502,6 +502,8 @@ void mymedic_dodge (edict_t *self, edict_t *attacker, vec3_t dir, int radius)
 {
 	if (random() > 0.9)
 		return;
+	if (!G_GetClient(self))
+		return;
 	if (level.time < self->monsterinfo.dodge_time)
 		return;
 	if (OnSameTeam(self, attacker))

--- a/src/entities/drone/drone_misc.c
+++ b/src/entities/drone/drone_misc.c
@@ -415,9 +415,8 @@ void drone_pain (edict_t *self, edict_t *other, float kick, int damage)
 	if ((self->s.modelindex != 255) && (self->health < (0.5*self->max_health)))
 		self->s.skinnum |= 1;
 
-	// keep track of damage by players in invasion mode
-//	if (INVASION_OTHERSPAWNS_REMOVED)
-//		AddDmgList(self, other, damage);
+	if (self->pain_inner)
+		self->pain_inner(self, other, kick, damage);
 
 	// ignore non-living objects
 	if (!G_EntIsAlive(other))
@@ -448,11 +447,6 @@ void drone_pain (edict_t *self, edict_t *other, float kick, int damage)
 		self->enemy = other;
 		drone_wakeallies(self);
 	}
-
-	// if this is a boss, then add attacker dmg to a list
-	// this list will be used to calculate exp for killing this monster
-//	if (self->monsterinfo.control_cost > 3)
-//		AddDmgList(self, other, damage);
 }
 
 void drone_death (edict_t *self, edict_t *attacker)
@@ -752,7 +746,6 @@ edict_t *vrx_create_drone_from_ent(edict_t *drone, edict_t *ent, int drone_type,
 
 	drone->activator = ent;
 	drone->svflags |= SVF_MONSTER;
-	drone->pain = drone_pain;
 	drone->yaw_speed = 20;
 	drone->takedamage = DAMAGE_AIM;
 	drone->clipmask = MASK_MONSTERSOLID;
@@ -804,6 +797,14 @@ edict_t *vrx_create_drone_from_ent(edict_t *drone, edict_t *ent, int drone_type,
 	// default
 	default: init_drone_gunner(drone);		break;
 	}
+
+	/* az: init functions might have set up a pain function -- address that here */
+	if (drone->pain && drone->pain != drone_pain)
+		drone->pain_inner = drone->pain;
+	else
+		drone->pain_inner = NULL; // maybe redundant?
+
+	drone->pain = drone_pain;
 
 	//4.0 gib health based on monster control cost
 	if (drone_type < 30)
@@ -1953,6 +1954,11 @@ qboolean M_Initialize (edict_t *ent, edict_t *monster, float dur_bonus)
 	monster->monsterinfo.bonus_flags = 0;//4.5 reset monster bonus flags
 
 	// set shared monster functions
+	if (monster->pain && monster->pain != drone_pain)
+		monster->pain_inner = monster->pain;
+	else
+		monster->pain_inner = NULL; // maybe redundant?
+
 	monster->pain = drone_pain;
 	monster->touch = drone_touch;
 	monster->think = drone_think;

--- a/src/entities/drone/drone_mutant.c
+++ b/src/entities/drone/drone_mutant.c
@@ -560,7 +560,7 @@ mframe_t mutant_frames_pain_short2[] =
 
 	ai_move, 0,  NULL,
 };
-mmove_t mutant_move_pain_short2 = { FRAME_pain301, FRAME_pain305, mutant_frames_pain_short2, mutant_run };
+mmove_t mutant_move_pain_short2 = { FRAME_pain101, FRAME_pain105, mutant_frames_pain_short2, mutant_run };
 
 void mutant_pain(edict_t* self, edict_t* other, float kick, int damage)
 {

--- a/src/entities/drone/drone_mutant.c
+++ b/src/entities/drone/drone_mutant.c
@@ -589,7 +589,15 @@ void mutant_pain(edict_t* self, edict_t* other, float kick, int damage)
 		self->monsterinfo.currentmove != &mutant_move_walk)
 		return;
 
-	gi.sound(self, CHAN_VOICE, sound_thud, 1, ATTN_NORM, 0);
+	if (self->monsterinfo.currentmove == &mutant_move_jump)
+		gi.sound(self, CHAN_VOICE, sound_thud, 1, ATTN_NORM, 0);
+	else
+	{
+		if (random() < 0.5)
+			gi.sound(self, CHAN_VOICE, sound_pain1, 1, ATTN_NORM, 0);
+		else
+			gi.sound(self, CHAN_VOICE, sound_pain2, 1, ATTN_NORM, 0);
+	}
 
 	if (self->monsterinfo.currentmove == &mutant_move_idle ||
 		self->monsterinfo.currentmove == &mutant_move_jump ||
@@ -617,8 +625,8 @@ void init_drone_mutant (edict_t *self)
 	sound_hit2 = gi.soundindex ("mutant/mutatck3.wav");
 	sound_death = gi.soundindex ("mutant/mutdeth1.wav");
 	sound_idle = gi.soundindex ("mutant/mutidle1.wav");
-	0;//sound_pain1 = gi.soundindex ("mutant/mutpain1.wav");
-	0;//sound_pain2 = gi.soundindex ("mutant/mutpain2.wav");
+	sound_pain1 = gi.soundindex ("mutant/mutpain1.wav");
+	sound_pain2 = gi.soundindex ("mutant/mutpain2.wav");
 	sound_sight = gi.soundindex ("mutant/mutsght1.wav");
 	0;//sound_search = gi.soundindex ("mutant/mutsrch1.wav");
 	sound_step1 = gi.soundindex ("mutant/step1.wav");

--- a/src/entities/drone/drone_soldier.c
+++ b/src/entities/drone/drone_soldier.c
@@ -415,6 +415,117 @@ void m_soldier_dead (edict_t *self)
 	M_PrepBodyRemoval(self);
 }
 
+
+mframe_t soldier_frames_pain_short1[] =
+{
+	ai_move, 0,	 NULL,
+	ai_move, 0,	 NULL,
+	ai_move, 0,	 NULL,
+	ai_move, 0, NULL,
+	ai_move, 0,	 NULL,
+};
+mmove_t soldier_move_pain_short1 = { FRAME_pain101, FRAME_pain105, soldier_frames_pain_short1, m_soldier_run };
+
+mframe_t soldier_frames_pain_short2[] =
+{
+	ai_move, 0,	 NULL,
+	ai_move, 0,	 NULL,
+	ai_move, 0,  NULL,
+	ai_move, 0,  NULL,
+	ai_move, 0,  NULL,
+	ai_move, 0,	 NULL,
+	ai_move, 0,	 NULL,
+};
+mmove_t soldier_move_pain_short2 = { FRAME_pain201, FRAME_pain207, soldier_frames_pain_short2, m_soldier_run };
+
+mframe_t soldier_frames_pain_long1[] =
+{
+	ai_move, 0,	 NULL,
+	ai_move, 0,	 NULL,
+	ai_move, 0,	 NULL,
+	ai_move, 0,  NULL,
+	ai_move, 0,  NULL,
+	ai_move, 0,	 NULL,
+	ai_move, 0,	 NULL,
+	ai_move, 0,	 NULL,
+	ai_move, 0,  NULL,
+	ai_move, 0,  NULL,
+	ai_move, 0,	 NULL,
+	ai_move, 0,	 NULL,
+	ai_move, 0,	 NULL,
+	ai_move, 0,  NULL,
+	ai_move, 0,  NULL,
+	ai_move, 0,	 NULL,
+	ai_move, 0,	 NULL,
+	ai_move, 0,	 NULL,
+};
+mmove_t soldier_move_pain_long1 = { FRAME_pain301, FRAME_pain318, soldier_frames_pain_long1, m_soldier_run };
+
+mframe_t soldier_frames_pain_long2[] =
+{
+	ai_move, 0,	 NULL,
+	ai_move, 0,	 NULL,
+	ai_move, 0,  NULL,
+	ai_move, 0,  NULL,
+	ai_move, 0,	 NULL,
+	ai_move, 0,	 NULL,
+	ai_move, 0,	 NULL,
+	ai_move, 0,  NULL,
+	ai_move, 0,  NULL,
+	ai_move, 0,	 NULL,
+	ai_move, 0,	 NULL,
+	ai_move, 0,	 NULL,
+	ai_move, 0,  NULL,
+	ai_move, 0,  NULL,	
+	ai_move, 0,	 NULL,
+	ai_move, 0,	 NULL,
+	ai_move, 0,	 NULL,
+};
+mmove_t soldier_move_pain_long2 = { FRAME_pain401, FRAME_pain417, soldier_frames_pain_long2, m_soldier_run };
+
+void soldier_pain(edict_t* self, edict_t* other, float kick, int damage)
+{
+	if (self->health < (self->max_health / 2))
+		self->s.skinnum = 1;
+
+	// we're already in a pain state
+	if (self->monsterinfo.currentmove == &soldier_move_pain_long1 ||
+		self->monsterinfo.currentmove == &soldier_move_pain_long2 ||
+		self->monsterinfo.currentmove == &soldier_move_pain_short1 || 
+		self->monsterinfo.currentmove == &soldier_move_pain_short2)
+		return;
+
+	// monster players don't get pain state induced
+	if (G_GetClient(self))
+		return;
+
+	// no pain in invasion hard mode
+	if (invasion->value == 2)
+		return;
+
+	// if we're fidgeting, always go into pain state.
+	if (random() <= (1.0f - self->monsterinfo.pain_chance) &&
+		self->monsterinfo.currentmove != &m_soldier_move_stand1 &&
+		self->monsterinfo.currentmove != &m_soldier_move_stand3)
+		return;
+
+	gi.sound(self, CHAN_VOICE, sound_pain, 1, ATTN_NORM, 0);
+
+	if (self->monsterinfo.currentmove == &m_soldier_move_stand1 ||
+		self->monsterinfo.currentmove == &m_soldier_move_stand3) {
+		if (random() < 0.5)
+			self->monsterinfo.currentmove = &soldier_frames_pain_long1;
+		else
+			self->monsterinfo.currentmove = &soldier_frames_pain_long2;
+	}
+	else {
+		if (random() < 0.5)
+			self->monsterinfo.currentmove = &soldier_move_pain_short1;
+		else
+			self->monsterinfo.currentmove = &soldier_move_pain_short2;
+	}
+}
+
 mframe_t m_soldier_frames_death1 [] =
 {
 	ai_move, 0,   NULL,
@@ -769,6 +880,9 @@ void init_drone_soldier (edict_t *self)
 	self->monsterinfo.jumpdn = 512;
 	self->monsterinfo.jumpup = 64;
 
+	// extremely sensitive to pain!
+	self->monsterinfo.pain_chance = 0.4f;
+	self->pain = soldier_pain;
 	self->die = m_soldier_die;
 
 	self->monsterinfo.stand = m_soldier_stand;

--- a/src/entities/drone/drone_soldier.c
+++ b/src/entities/drone/drone_soldier.c
@@ -432,6 +432,7 @@ mframe_t soldier_frames_pain_short2[] =
 	ai_move, 0,	 NULL,
 	ai_move, 0,  NULL,
 	ai_move, 0,  NULL,
+
 	ai_move, 0,  NULL,
 	ai_move, 0,	 NULL,
 	ai_move, 0,	 NULL,
@@ -444,18 +445,22 @@ mframe_t soldier_frames_pain_long1[] =
 	ai_move, 0,	 NULL,
 	ai_move, 0,	 NULL,
 	ai_move, 0,  NULL,
+
 	ai_move, 0,  NULL,
 	ai_move, 0,	 NULL,
 	ai_move, 0,	 NULL,
 	ai_move, 0,	 NULL,
+
 	ai_move, 0,  NULL,
 	ai_move, 0,  NULL,
 	ai_move, 0,	 NULL,
 	ai_move, 0,	 NULL,
+
 	ai_move, 0,	 NULL,
 	ai_move, 0,  NULL,
 	ai_move, 0,  NULL,
 	ai_move, 0,	 NULL,
+
 	ai_move, 0,	 NULL,
 	ai_move, 0,	 NULL,
 };
@@ -467,18 +472,22 @@ mframe_t soldier_frames_pain_long2[] =
 	ai_move, 0,	 NULL,
 	ai_move, 0,  NULL,
 	ai_move, 0,  NULL,
+
 	ai_move, 0,	 NULL,
 	ai_move, 0,	 NULL,
 	ai_move, 0,	 NULL,
 	ai_move, 0,  NULL,
+
 	ai_move, 0,  NULL,
 	ai_move, 0,	 NULL,
 	ai_move, 0,	 NULL,
 	ai_move, 0,	 NULL,
+
 	ai_move, 0,  NULL,
 	ai_move, 0,  NULL,	
 	ai_move, 0,	 NULL,
 	ai_move, 0,	 NULL,
+
 	ai_move, 0,	 NULL,
 };
 mmove_t soldier_move_pain_long2 = { FRAME_pain401, FRAME_pain417, soldier_frames_pain_long2, m_soldier_run };
@@ -514,9 +523,9 @@ void soldier_pain(edict_t* self, edict_t* other, float kick, int damage)
 	if (self->monsterinfo.currentmove == &m_soldier_move_stand1 ||
 		self->monsterinfo.currentmove == &m_soldier_move_stand3) {
 		if (random() < 0.5)
-			self->monsterinfo.currentmove = &soldier_frames_pain_long1;
+			self->monsterinfo.currentmove = &soldier_move_pain_long1;
 		else
-			self->monsterinfo.currentmove = &soldier_frames_pain_long2;
+			self->monsterinfo.currentmove = &soldier_move_pain_long2;
 	}
 	else {
 		if (random() < 0.5)

--- a/src/entities/drone/drone_tank.c
+++ b/src/entities/drone/drone_tank.c
@@ -922,7 +922,12 @@ mmove_t tank_move_pain_short2 = { FRAME_pain101, FRAME_pain104, tank_frames_pain
 
 void tank_pain(edict_t* self, edict_t* other, float kick, int damage)
 {
-	double rng = random();
+	const double rng = random();
+	const qboolean is_idling = self->monsterinfo.currentmove == &tank_move_start_walk ||
+		self->monsterinfo.currentmove == &tank_move_stop_walk ||
+		self->monsterinfo.currentmove == &mytank_move_stand;
+	const qboolean moving_without_enemy = self->monsterinfo.currentmove == &tank_move_walk && !self->enemy;
+
 	if (self->health < (self->max_health / 2))
 		self->s.skinnum = 1;
 
@@ -942,17 +947,12 @@ void tank_pain(edict_t* self, edict_t* other, float kick, int damage)
 
 	// if we're fidgeting, always go into pain state.
 	if (rng <= (1.0f - self->monsterinfo.pain_chance) &&
-		self->monsterinfo.currentmove != &tank_move_start_walk &&
-		self->monsterinfo.currentmove != &tank_move_stop_walk &&
-		self->monsterinfo.currentmove != &mytank_move_stand)
+		!(is_idling || moving_without_enemy))
 		return;
 
 	gi.sound(self, CHAN_VOICE, sound_pain, 1, ATTN_NORM, 0);
 
-	if (self->monsterinfo.currentmove == &tank_move_start_walk ||
-		self->monsterinfo.currentmove == &mytank_move_stand ||
-		// walking only if there's no enemy
-		(self->monsterinfo.currentmove == &tank_move_walk && !self->enemy)) 
+	if (is_idling || moving_without_enemy) 
 		self->monsterinfo.currentmove = &tank_move_pain_long;
 	else {
 		if (random() < 0.5)

--- a/src/entities/drone/drone_tank.c
+++ b/src/entities/drone/drone_tank.c
@@ -950,7 +950,9 @@ void tank_pain(edict_t* self, edict_t* other, float kick, int damage)
 	gi.sound(self, CHAN_VOICE, sound_pain, 1, ATTN_NORM, 0);
 
 	if (self->monsterinfo.currentmove == &tank_move_start_walk ||
-		self->monsterinfo.currentmove == &mytank_move_stand)
+		self->monsterinfo.currentmove == &mytank_move_stand ||
+		// walking only if there's no enemy
+		(self->monsterinfo.currentmove == &tank_move_walk && !self->enemy)) 
 		self->monsterinfo.currentmove = &tank_move_pain_long;
 	else {
 		if (random() < 0.5)

--- a/src/entities/drone/drone_tank.c
+++ b/src/entities/drone/drone_tank.c
@@ -950,7 +950,9 @@ void tank_pain(edict_t* self, edict_t* other, float kick, int damage)
 	gi.sound(self, CHAN_VOICE, sound_pain, 1, ATTN_NORM, 0);
 
 	if (self->monsterinfo.currentmove == &tank_move_start_walk ||
-		self->monsterinfo.currentmove == &mytank_move_stand)
+		self->monsterinfo.currentmove == &mytank_move_stand ||
+		// walking only if there's no enemy
+		(self->monsterinfo.currentmove == &tank_frames_walk && !self->enemy)) 
 		self->monsterinfo.currentmove = &tank_move_pain_long;
 	else {
 		if (random() < 0.5)

--- a/src/g_local.h
+++ b/src/g_local.h
@@ -636,6 +636,9 @@ typedef struct
 	// drone list
 	int dronelist_index;
 
+	// odds that a hit will induce a pain state
+	float pain_chance;
+
 	// az end
 } monsterinfo_t;
 

--- a/src/g_local.h
+++ b/src/g_local.h
@@ -1783,6 +1783,7 @@ struct edict_s
 	void		(*touch)(edict_t *self, edict_t *other, cplane_t *plane, csurface_t *surf);
 	void		(*use)(edict_t *self, edict_t *other, edict_t *activator);
 	void		(*pain)(edict_t *self, edict_t *other, float kick, int damage);
+	void		(*pain_inner)(edict_t* self, edict_t* other, float kick, int damage); // az: for monsters that use drone_pain
 	void		(*die)(edict_t *self, edict_t *inflictor, edict_t *attacker, int damage, vec3_t point);
 
 	float		touch_debounce_time;		// are all these legit?  do we need more/less of them?


### PR DESCRIPTION
Adds pain states to monsters. If they were unaware, they go into the longest pain animation they have. Otherwise it rolls between the shorter ones. They work through chance. Player monsters won't go into a pain state. Also worldspawn monsters won't dodge. 
Chances are generally < 40% per shot. 