### PR TITLE
Improving some mission pack weapons and trap/teslas behavior, rotative weapon bindings

### DIFF
--- a/src/characters/class_limits.c
+++ b/src/characters/class_limits.c
@@ -142,6 +142,12 @@ int MAX_BULLETS(const struct edict_s *ent) {
     return (100 * ent->myskills.abilities[MAX_AMMO].current_level);
 }
 
+int MAX_ROUNDS(const struct edict_s *ent) {
+    if (ent->myskills.abilities[MAX_AMMO].disable)
+        return 0;
+    return (3 * ent->myskills.abilities[MAX_AMMO].current_level);
+}
+
 int MAX_SHELLS(const struct edict_s *ent) {
     if (ent->myskills.abilities[MAX_AMMO].disable)
         return 0;
@@ -246,6 +252,7 @@ void vrx_update_all_character_maximums(edict_t *ent) {
     ent->client->pers.max_grenades = 50 + MAX_GRENADES(ent);
     ent->client->pers.max_cells = 200 + MAX_CELLS(ent);
     ent->client->pers.max_slugs = 50 + MAX_SLUGS(ent);
+    ent->client->pers.max_disruptor = 12 + MAX_ROUNDS(ent);
 
     ent->client->pers.max_powercubes = MAX_POWERCUBES(ent);
 }

--- a/src/characters/class_limits.h
+++ b/src/characters/class_limits.h
@@ -20,6 +20,8 @@ int MAX_CELLS(const struct edict_s *ent);
 
 int MAX_SLUGS(const struct edict_s *ent);
 
+int MAX_ROUNDS(const struct edict_s *ent);
+
 int MAX_POWERCUBES(const struct edict_s *ent);
 
 int MAX_POWERCUBES(const struct edict_s *ent);

--- a/src/characters/settings.h
+++ b/src/characters/settings.h
@@ -74,7 +74,7 @@ enum vrx_player_class_t {
     CLASS_MAX // Number of classes to choose from + 1
 };
 
-#define ARMORY_ITEMS 38
+#define ARMORY_ITEMS 39
 
 #define PLAYTIME_MIN_MINUTES        999.0    // minutes played before penalty begins
 #define PLAYTIME_MAX_MINUTES        999.0    // minutes played before max penalty is reached

--- a/src/characters/v_utils.c
+++ b/src/characters/v_utils.c
@@ -184,6 +184,8 @@ char *GetArmoryItemString(int purchase_number) {
             return "Chainfist";
         case 38:
             return "Tesla";
+        case 39:
+            return "Disruptor";
         default:
             return " ";
     }
@@ -1337,6 +1339,11 @@ qboolean V_GiveAmmoClip(edict_t *ent, float qty, int ammotype) {
             current = &ent->client->pers.inventory[tesla_index];
             max = &ent->client->pers.max_tesla;
             break;
+        case AMMO_DISRUPTOR:
+            amount = 3;
+            current = &ent->client->pers.inventory[disruptor_index];
+            max = &ent->client->pers.max_disruptor;
+            break;
         default:
             return false;
     }
@@ -1398,6 +1405,8 @@ int V_GetRespawnAmmoType(edict_t *ent) {
         case 14: //ionripper
         case 18: //plasma beam
             return AMMO_CELLS;
+        case 22: //disruptor
+            return AMMO_DISRUPTOR;
         default: //blaster/sword
             return 0; //nothing
     }

--- a/src/combat/abilities/supplystation.c
+++ b/src/combat/abilities/supplystation.c
@@ -179,6 +179,8 @@ int MaxAmmoType (edict_t *ent, int ammo_index)
 		return ent->client->pers.max_trap;
 	else if (ammo_index == tesla_index)
 		return ent->client->pers.max_tesla;
+	else if (ammo_index == disruptor_index)
+		return ent->client->pers.max_disruptor;
 	else return 0;
 }
 
@@ -282,6 +284,9 @@ int G_GetAmmoIndexByWeaponIndex (int weapon_index)
 	item = FindItem("Tesla");
 	if (item && weapon_index == ITEM_INDEX(item))
 		return tesla_index;
+	item = FindItem("Disruptor");
+	if (item && weapon_index == ITEM_INDEX(item))
+		return disruptor_index;
 	if (weapon_index == grenade_index)
 		return grenade_index;
 	return 0;

--- a/src/combat/common/damage.c
+++ b/src/combat/common/damage.c
@@ -105,6 +105,7 @@ int G_DamageType(int mod, int dflags) {
         case MOD_BFG_EFFECT:
         case MOD_HYPERBLASTER:
         case MOD_BLASTER:
+        case MOD_TRACKER:
         case MOD_SWORD:
             return (D_ENERGY | D_PHYSICAL);
         case MOD_LASER_DEFENSE:

--- a/src/combat/common/g_items.c
+++ b/src/combat/common/g_items.c
@@ -43,6 +43,7 @@ int cell_index;
 int magslug_index;
 int trap_index;
 int tesla_index;
+int disruptor_index;
 
 //weapons
 int sword_index;
@@ -2262,6 +2263,25 @@ always owned, never in the world
                         AMMO_TESLA,
 /* precache */ "models/weapons/v_tesla2/tris.md2 weapons/teslaopen.wav weapons/hgrenb1a.wav weapons/hgrenb2a.wav models/weapons/g_tesla/tris.md2"
                 },
+                {
+                        "ammo_disruptor",
+                        Pickup_Ammo,
+                        NULL,
+                        Drop_Ammo,
+                        NULL,
+                        "misc/am_pkup.wav",
+                        "models/items/ammo/bullets/medium/tris.md2", 0,
+                        NULL,
+/* icon */        "a_bullets",
+/* pickup */    "Rounds",
+/* width */        3,
+                        3,
+                        NULL,
+                        IT_AMMO,
+                        NULL,
+                        AMMO_DISRUPTOR,
+/* precache */ ""
+                },
 
                 {
                         "ammo_slugs",
@@ -3021,6 +3041,27 @@ warehouse circuits
                         "ctf/tech3.wav"                                    // precache sound
                 },
 
+                {
+                        "weapon_disintegrator",
+                        Pickup_Weapon,
+                        Use_Weapon,
+                        Drop_Weapon,
+                        Weapon_Disruptor,
+                        "misc/w_pkup.wav",
+                        "models/weapons/g_dist/tris.md2", EF_ROTATE | EF_BOB,
+                        "models/weapons/v_dist/tris.md2",
+/* icon */        "w_disintegrator",
+/* pickup */    "Disruptor",
+                        0,
+                        1,
+                        "Rounds",
+                        IT_WEAPON,
+                        NULL,
+                        0,
+/* precache */ "models/weapons/g_dist/tris.md2 models/weapons/v_dist/tris.md2 models/proj/disintegrator/tris.md2 weapons/disrupt.wav weapons/disint2.wav weapons/disrupthit.wav a_bullets_hud",
+                        WEAP_BFG
+                },
+
                 // end of list marker
                 {NULL}
         };
@@ -3147,6 +3188,7 @@ void SetItemNames(void) {
     magslug_index = ITEM_INDEX(FindItem("Mag Slug"));
     trap_index = ITEM_INDEX(FindItem("Trap"));
     tesla_index = ITEM_INDEX(FindItem("Tesla Ammo"));
+    disruptor_index = ITEM_INDEX(FindItem("Rounds"));
 
     //weapons
     sword_index = ITEM_INDEX(FindItem("Sword"));

--- a/src/combat/common/v_client.c
+++ b/src/combat/common/v_client.c
@@ -205,6 +205,9 @@ int vrx_WeapIDtoWeapIndex(int weaponID)
     case 21:
         item = FindItem("Tesla");
         return item ? ITEM_INDEX(item) : blaster_index;
+    case 22:
+        item = FindItem("Disruptor");
+        return item ? ITEM_INDEX(item) : blaster_index;
     default: return blaster_index;
     }
 }

--- a/src/combat/weapons/g_weap_missionpack.c
+++ b/src/combat/weapons/g_weap_missionpack.c
@@ -24,6 +24,7 @@ static void prox_open(edict_t *ent);
 static void prox_land(edict_t *ent, edict_t *other, cplane_t *plane, csurface_t *surf);
 
 static void tesla_remove(edict_t *self);
+static void tesla_remove_ownerdead(edict_t *self);
 static void tesla_die(edict_t *self, edict_t *inflictor, edict_t *attacker, int damage, vec3_t point);
 static void tesla_blow(edict_t *self);
 static void tesla_zap(edict_t *self, edict_t *other, cplane_t *plane, csurface_t *surf);
@@ -31,6 +32,407 @@ static void tesla_think_active(edict_t *self);
 static void tesla_activate(edict_t *self);
 static void tesla_think(edict_t *ent);
 static void tesla_lava(edict_t *ent, edict_t *other, cplane_t *plane, csurface_t *surf);
+static void trap_touch(edict_t *ent, edict_t *other, cplane_t *plane, csurface_t *surf);
+static qboolean trap_owner_active(edict_t *ent);
+static void trap_blow(edict_t *ent);
+static void trap_remove(edict_t *ent);
+static qboolean trap_pull_target(edict_t *ent, edict_t *target, int pull);
+static void tracker_touch(edict_t *self, edict_t *other, cplane_t *plane, csurface_t *surf);
+static void tracker_fly(edict_t *self);
+static void tracker_pain_daemon_think(edict_t *self);
+
+#define TRACKER_DAMAGE_FLAGS (DAMAGE_ENERGY | DAMAGE_NO_KNOCKBACK)
+#define TRACKER_IMPACT_FLAGS DAMAGE_ENERGY
+#define TRACKER_DAMAGE_TIME 0.5f
+
+static qboolean deployable_stick(edict_t *ent, edict_t *other, cplane_t *plane, csurface_t *surf)
+{
+    vec3_t dir;
+    float half_width;
+    float depth_adjust;
+    float original_max_z;
+    qboolean tesla_mount;
+
+    if (surf && (surf->flags & SURF_SKY))
+    {
+        G_FreeEdict(ent);
+        return true;
+    }
+
+    if (!plane)
+        return false;
+
+    if (other && (((other->svflags & SVF_MONSTER) != 0) || other->client || other->takedamage))
+        return false;
+
+    if (plane->normal[2] < 0.7f)
+    {
+        original_max_z = ent->maxs[2];
+        half_width = fabs(ent->maxs[0]);
+        depth_adjust = original_max_z - half_width;
+        tesla_mount = ent->classname && !strcmp(ent->classname, "tesla");
+
+        if (tesla_mount && plane->normal[2] < -0.7f)
+            depth_adjust = original_max_z;
+        else if (tesla_mount)
+            depth_adjust = half_width;
+
+        if (depth_adjust > 0)
+            VectorMA(ent->s.origin, -depth_adjust, plane->normal, ent->s.origin);
+
+        ent->mins[2] = -half_width;
+        ent->maxs[2] = half_width;
+    }
+
+    VectorClear(ent->velocity);
+    VectorClear(ent->avelocity);
+    vectoangles(plane->normal, dir);
+    dir[PITCH] += 90;
+    VectorCopy(dir, ent->s.angles);
+    VectorCopy(plane->normal, ent->movedir);
+    ent->movetype = MOVETYPE_NONE;
+    ent->groundentity = other;
+    ent->touch = NULL;
+    gi.linkentity(ent);
+    return true;
+}
+
+static qboolean trap_owner_active(edict_t *ent)
+{
+    return G_EntExists(ent->owner) &&
+        (!ent->owner->client || (ent->owner->health > 0 && ent->owner->deadflag != DEAD_DEAD));
+}
+
+static void deployable_hud_remove(edict_t *ent)
+{
+    edict_t *owner = ent->activator;
+
+    if (!G_EntExists(owner))
+        owner = ent->owner;
+    if (owner && owner->client)
+        layout_remove_tracked_entity(&owner->client->layout, ent);
+}
+
+static void trap_blow(edict_t *ent)
+{
+    edict_t *owner = ent->owner;
+    vec3_t origin;
+
+    deployable_hud_remove(ent);
+
+    if (!G_EntExists(owner))
+        owner = ent;
+
+    ent->takedamage = DAMAGE_NO;
+    ent->solid = SOLID_NOT;
+    ent->touch = NULL;
+
+    if (owner->client && !(owner->svflags & SVF_DEADMONSTER))
+        PlayerNoise(owner, ent->s.origin, PNOISE_IMPACT);
+
+    T_RadiusDamage(ent, owner, ent->dmg, ent, ent->dmg_radius, MOD_TRAP);
+
+    VectorMA(ent->s.origin, -0.02, ent->velocity, origin);
+    gi.WriteByte(svc_temp_entity);
+    if (ent->waterlevel)
+    {
+        if (ent->groundentity)
+            gi.WriteByte(TE_GRENADE_EXPLOSION_WATER);
+        else
+            gi.WriteByte(TE_ROCKET_EXPLOSION_WATER);
+    }
+    else
+    {
+        if (ent->groundentity || ent->movetype == MOVETYPE_NONE)
+            gi.WriteByte(TE_GRENADE_EXPLOSION);
+        else
+            gi.WriteByte(TE_ROCKET_EXPLOSION);
+    }
+    gi.WritePosition(origin);
+    gi.multicast(ent->s.origin, MULTICAST_PHS);
+
+    G_FreeEdict(ent);
+}
+
+static void trap_remove(edict_t *ent)
+{
+    deployable_hud_remove(ent);
+    ent->takedamage = DAMAGE_NO;
+    ent->solid = SOLID_NOT;
+    ent->touch = NULL;
+    ent->nextthink = level.time + FRAMETIME;
+    ent->think = BecomeExplosion1;
+}
+
+void RemoveOwnedDeployables(edict_t *owner)
+{
+    edict_t *ent;
+
+    if (!G_EntExists(owner))
+        return;
+
+    for (ent = g_edicts; ent < &g_edicts[globals.num_edicts]; ent++)
+    {
+        if (!ent->inuse || !ent->classname)
+            continue;
+
+        if (!strcmp(ent->classname, "htrap"))
+        {
+            if (ent->owner == owner || ent->activator == owner)
+                trap_remove(ent);
+            continue;
+        }
+
+        if (!strcmp(ent->classname, "tesla"))
+        {
+            if (ent->teammaster == owner || ent->owner == owner)
+                tesla_remove_ownerdead(ent);
+        }
+    }
+}
+
+static qboolean trap_pull_target(edict_t *ent, edict_t *target, int pull)
+{
+    vec3_t start, end, dir;
+
+    G_EntMidPoint(target, end);
+    G_EntMidPoint(ent, start);
+    VectorSubtract(start, end, dir);
+    VectorNormalize(dir);
+
+    if (target->groundentity)
+        pull *= 2;
+
+    if (target->groundentity)
+    {
+        target->s.origin[2] += 1;
+        target->groundentity = NULL;
+    }
+
+    VectorMA(target->velocity, pull, dir, target->velocity);
+    return true;
+}
+
+static void tracker_explode(edict_t *self)
+{
+    gi.sound(self, CHAN_AUTO, gi.soundindex("weapons/disrupthit.wav"), 1, ATTN_NORM, 0);
+
+    gi.WriteByte(svc_temp_entity);
+    gi.WriteByte(TE_TRACKER_EXPLOSION);
+    gi.WritePosition(self->s.origin);
+    gi.multicast(self->s.origin, MULTICAST_PHS);
+
+    G_FreeEdict(self);
+}
+
+static void tracker_pain_daemon_think(edict_t *self)
+{
+    vec3_t pain_normal = {0, 0, 1};
+    vec3_t center;
+    int hurt;
+
+    if (!self->inuse)
+        return;
+
+    if (!self->enemy || !self->enemy->inuse)
+    {
+        G_FreeEdict(self);
+        return;
+    }
+
+    if ((level.time - self->timestamp) > TRACKER_DAMAGE_TIME)
+    {
+        if (!self->enemy->client)
+            self->enemy->s.effects &= ~EF_TRACKERTRAIL;
+        G_FreeEdict(self);
+        return;
+    }
+
+    if (self->enemy->health < 1)
+    {
+        if (!self->enemy->client)
+            self->enemy->s.effects &= ~EF_TRACKERTRAIL;
+        G_FreeEdict(self);
+        return;
+    }
+
+    G_EntMidPoint(self->enemy, center);
+    T_Damage(self->enemy, self, self->owner, vec3_origin, center, pain_normal,
+        self->dmg, 0, TRACKER_DAMAGE_FLAGS, MOD_TRACKER);
+
+    if (!self->inuse)
+        return;
+
+    if (self->enemy->health < 1)
+    {
+        hurt = self->enemy->gib_health ? -self->enemy->gib_health : 500;
+        T_Damage(self->enemy, self, self->owner, vec3_origin, center, pain_normal,
+            hurt, 0, TRACKER_DAMAGE_FLAGS, MOD_TRACKER);
+    }
+
+    self->nextthink = level.time + 0.1f;
+
+    if (!self->enemy->client)
+        self->enemy->s.effects |= EF_TRACKERTRAIL;
+}
+
+static void tracker_pain_daemon_spawn(edict_t *owner, edict_t *enemy, int damage)
+{
+    edict_t *daemon;
+
+    if (!enemy)
+        return;
+
+    daemon = G_Spawn();
+    daemon->classname = "pain daemon";
+    daemon->think = tracker_pain_daemon_think;
+    daemon->nextthink = level.time;
+    daemon->timestamp = level.time;
+    daemon->owner = owner;
+    daemon->enemy = enemy;
+    daemon->dmg = damage;
+}
+
+static void tracker_touch(edict_t *self, edict_t *other, cplane_t *plane, csurface_t *surf)
+{
+    vec3_t normal;
+    float damagetime;
+
+    if (other == self->owner)
+        return;
+
+    if (self->owner && G_EntExists(other) && OnSameTeam(self->owner, other))
+        return;
+
+    if (surf && (surf->flags & SURF_SKY))
+    {
+        G_FreeEdict(self);
+        return;
+    }
+
+    if (self->owner && self->owner->client)
+        PlayerNoise(self->owner, self->s.origin, PNOISE_IMPACT);
+
+    if (other->takedamage)
+    {
+        if (plane)
+            VectorCopy(plane->normal, normal);
+        else
+            VectorClear(normal);
+
+        if ((other->svflags & SVF_MONSTER) || other->client)
+        {
+            if (other->health > 0)
+            {
+                T_Damage(other, self, self->owner, self->velocity, self->s.origin, normal,
+                    0, self->dmg * 3, TRACKER_IMPACT_FLAGS, MOD_TRACKER);
+
+                if (!(other->flags & (FL_FLY | FL_SWIM)))
+                    other->velocity[2] += 140;
+
+                damagetime = (self->dmg * 0.1f) / TRACKER_DAMAGE_TIME;
+                tracker_pain_daemon_spawn(self->owner, other, (int)damagetime);
+
+                if (!other->client)
+                    other->s.effects |= EF_TRACKERTRAIL;
+            }
+            else
+            {
+                T_Damage(other, self, self->owner, self->velocity, self->s.origin, normal,
+                    self->dmg * 4, self->dmg * 3, TRACKER_IMPACT_FLAGS, MOD_TRACKER);
+            }
+        }
+        else
+        {
+            T_Damage(other, self, self->owner, self->velocity, self->s.origin, normal,
+                self->dmg, self->dmg * 3, TRACKER_IMPACT_FLAGS, MOD_TRACKER);
+        }
+    }
+
+    tracker_explode(self);
+}
+
+static void tracker_fly(edict_t *self)
+{
+    vec3_t dest, dir;
+
+    if (!G_ValidTarget(self->owner, self->enemy, false, true))
+    {
+        tracker_explode(self);
+        return;
+    }
+
+    if (self->enemy->client)
+    {
+        VectorCopy(self->enemy->s.origin, dest);
+        dest[2] += self->enemy->viewheight;
+    }
+    else
+    {
+        G_EntMidPoint(self->enemy, dest);
+    }
+
+    VectorSubtract(dest, self->s.origin, dir);
+    VectorNormalize(dir);
+    vectoangles(dir, self->s.angles);
+    VectorScale(dir, self->speed, self->velocity);
+
+    self->nextthink = level.time + 0.1f;
+}
+
+void fire_disruptor(edict_t *self, vec3_t start, vec3_t dir, int damage, int speed, edict_t *enemy)
+{
+    edict_t *bolt;
+    trace_t tr;
+
+    VectorNormalize(dir);
+
+    bolt = G_Spawn();
+    VectorCopy(start, bolt->s.origin);
+    VectorCopy(start, bolt->s.old_origin);
+    vectoangles(dir, bolt->s.angles);
+    VectorScale(dir, speed, bolt->velocity);
+
+    bolt->movetype = MOVETYPE_FLYMISSILE;
+    bolt->clipmask = MASK_SHOT;
+    bolt->solid = SOLID_BBOX;
+    bolt->svflags |= SVF_PROJECTILE;
+    bolt->s.effects = EF_TRACKER;
+
+    VectorClear(bolt->mins);
+    VectorClear(bolt->maxs);
+    bolt->s.modelindex = gi.modelindex("models/proj/disintegrator/tris.md2");
+    bolt->owner = self;
+    bolt->touch = tracker_touch;
+    bolt->enemy = enemy;
+    bolt->speed = speed;
+    bolt->dmg = damage;
+    bolt->classname = "tracker";
+    bolt->s.sound = gi.soundindex("weapons/disrupt.wav");
+
+    if (enemy)
+    {
+        bolt->nextthink = level.time + 0.1f;
+        bolt->think = tracker_fly;
+    }
+    else
+    {
+        bolt->nextthink = level.time + 7.0f;
+        bolt->think = G_FreeEdict;
+    }
+
+    gi.linkentity(bolt);
+
+    if (self->client)
+        check_dodge(self, bolt->s.origin, dir, speed, damage);
+
+    tr = gi.trace(self->s.origin, NULL, NULL, bolt->s.origin, bolt, MASK_SHOT);
+    if (tr.fraction < 1.0)
+    {
+        VectorMA(bolt->s.origin, 1.0f, tr.plane.normal, bolt->s.origin);
+        bolt->touch(bolt, tr.ent, &tr.plane, tr.surface);
+    }
+}
 
 // RAFAEL
 /*
@@ -539,17 +941,21 @@ static void Trap_Think (edict_t *ent)
     int		oldlen = 8000;
     vec3_t	forward, right, up;
 
+    if (!trap_owner_active(ent))
+    {
+        trap_remove(ent);
+        return;
+    }
+
     if (ent->timestamp < level.time)
     {
-        BecomeExplosion1(ent);
-        // note to self
-        // cause explosion damage???
+        trap_blow(ent);
         return;
     }
 
     ent->nextthink = level.time + 0.1;
 
-    if (!ent->groundentity)
+    if (!ent->groundentity && ent->movetype != MOVETYPE_NONE)
         return;
 
     // ok lets do the blood effect
@@ -639,9 +1045,10 @@ static void Trap_Think (edict_t *ent)
     }
 
     ent->s.effects &= ~EF_TRAP;
+    ent->s.effects &= ~EF_GRENADE;
     if (ent->s.frame >= 4)
     {
-        ent->s.effects |= EF_TRAP;
+        ent->s.effects |= EF_GRENADE;
         VectorClear (ent->mins);
         VectorClear (ent->maxs);
 
@@ -656,8 +1063,14 @@ static void Trap_Think (edict_t *ent)
             continue;
         if (!(target->svflags & SVF_MONSTER) && !target->client)
             continue;
-        // if (target == ent->owner)
-        //	continue;
+        if (target == ent->owner)
+        {
+            // Optional self-damage/self-pull:
+            // comment out this block if you want traps to affect their owner too.
+            continue;
+        }
+        if (OnSameTeam(ent, target))
+            continue;
         if (target->health <= 0)
             continue;
         if (!visible (ent, target))
@@ -679,27 +1092,9 @@ static void Trap_Think (edict_t *ent)
     // pull the enemy in
     if (best)
     {
-        vec3_t	forward;
-
-        if (best->groundentity)
-        {
-            best->s.origin[2] += 1;
-            best->groundentity = NULL;
-        }
         VectorSubtract (ent->s.origin, best->s.origin, vec);
         len = VectorLength (vec);
-        if (best->client)
-        {
-            VectorNormalize (vec);
-            VectorMA (best->velocity, 250, vec, best->velocity);
-        }
-        else
-        {
-            best->ideal_yaw = vectoyaw(vec);
-//			M_ChangeYaw (best);
-            AngleVectors (best->s.angles, forward, NULL, NULL);
-            VectorScale (forward, 256, best->velocity);
-        }
+        trap_pull_target(ent, best, 250);
 
         gi.sound(ent, CHAN_VOICE, gi.soundindex ("weapons/trapsuck.wav"), 1, ATTN_IDLE, 0);
 
@@ -721,14 +1116,17 @@ static void Trap_Think (edict_t *ent)
             }
             else
             {
-                BecomeExplosion1(ent);
-                // note to self
-                // cause explosion damage???
+                trap_blow(ent);
                 return;
             }
 
         }
     }
+}
+
+static void trap_touch(edict_t *ent, edict_t *other, cplane_t *plane, csurface_t *surf)
+{
+    deployable_stick(ent, other, plane, surf);
 }
 
 void fire_trap (edict_t *self, vec3_t start, vec3_t aimdir, int damage, int speed, float timer, float damage_radius, qboolean held)
@@ -753,8 +1151,10 @@ void fire_trap (edict_t *self, vec3_t start, vec3_t aimdir, int damage, int spee
     VectorSet(trap->maxs, 4, 4, 8);
     trap->s.modelindex = gi.modelindex("models/weapons/z_trap/tris.md2");
     trap->owner = self;
+    trap->activator = self;
     trap->nextthink = level.time + 1.0;
     trap->think = Trap_Think;
+    trap->touch = trap_touch;
     trap->dmg = damage;
     trap->dmg_radius = damage_radius;
     trap->classname = "htrap";
@@ -762,11 +1162,17 @@ void fire_trap (edict_t *self, vec3_t start, vec3_t aimdir, int damage, int spee
     trap->spawnflags = held ? 3 : 1;
 
     if (timer <= 0.0)
+    {
         Grenade_Explode(trap);
-    else
-        gi.linkentity(trap);
+        return;
+    }
 
+    trap->mtype = M_TRAP;
     trap->timestamp = level.time + 30;
+    gi.linkentity(trap);
+
+    if (self->client)
+        layout_add_tracked_entity(&self->client->layout, trap);
 }
 
 static void Prox_Explode(edict_t *ent)
@@ -1016,6 +1422,7 @@ static void tesla_remove(edict_t *self)
     edict_t *owner = self->teammaster;
     vec3_t origin;
 
+    deployable_hud_remove(self);
     self->takedamage = DAMAGE_NO;
 
     cur = self->teamchain;
@@ -1057,6 +1464,28 @@ static void tesla_remove(edict_t *self)
     G_FreeEdict(self);
 }
 
+static void tesla_remove_ownerdead(edict_t *self)
+{
+    edict_t *cur, *next;
+
+    deployable_hud_remove(self);
+    self->takedamage = DAMAGE_NO;
+    self->solid = SOLID_NOT;
+    self->touch = NULL;
+
+    cur = self->teamchain;
+    while (cur)
+    {
+        next = cur->teamchain;
+        G_FreeEdict(cur);
+        cur = next;
+    }
+    self->teamchain = NULL;
+
+    self->nextthink = level.time + FRAMETIME;
+    self->think = BecomeExplosion1;
+}
+
 static void tesla_die(edict_t *self, edict_t *inflictor, edict_t *attacker, int damage, vec3_t point)
 {
     tesla_remove(self);
@@ -1079,6 +1508,7 @@ static void tesla_think_active(edict_t *self)
     edict_t *touch[MAX_EDICTS], *hit;
     edict_t *attacker = self->teammaster;
     vec3_t dir, start, normal;
+    vec3_t offset;
     trace_t tr;
 
     if (!self->teamchain || !self->teamchain->inuse || level.time > self->air_finished)
@@ -1087,11 +1517,20 @@ static void tesla_think_active(edict_t *self)
         return;
     }
 
-    if (!G_EntExists(attacker))
-        attacker = self;
+    if (!G_EntExists(attacker) || (attacker->client && (attacker->health <= 0 || attacker->deadflag == DEAD_DEAD)))
+    {
+        tesla_remove_ownerdead(self);
+        return;
+    }
 
-    VectorCopy(self->s.origin, start);
-    start[2] += 16;
+    G_EntMidPoint(self, start);
+    if (VectorLength(self->movedir) > 0)
+    {
+        VectorScale(self->movedir, 16, offset);
+        VectorAdd(start, offset, start);
+    }
+    else
+        start[2] += 16;
 
     num = gi.BoxEdicts(self->teamchain->absmin, self->teamchain->absmax, touch, MAX_EDICTS, AREA_SOLID);
     for (i = 0; i < num; i++)
@@ -1106,12 +1545,15 @@ static void tesla_think_active(edict_t *self)
             continue;
         if (hit == attacker)
             continue;
+        if (OnSameTeam(self, hit))
+            continue;
 
-        tr = gi.trace(start, vec3_origin, vec3_origin, hit->s.origin, self, MASK_SHOT);
+        G_EntMidPoint(hit, dir);
+        tr = gi.trace(start, vec3_origin, vec3_origin, dir, self, MASK_SHOT);
         if (!(tr.fraction == 1.0f || tr.ent == hit))
             continue;
 
-        VectorSubtract(hit->s.origin, start, dir);
+        VectorSubtract(dir, start, dir);
         if (tr.fraction == 1.0f)
             VectorClear(normal);
         else
@@ -1140,6 +1582,12 @@ static void tesla_activate(edict_t *self)
     edict_t *trigger;
     float radius = self->dmg_radius;
 
+    if (!G_EntExists(self->teammaster) || (self->teammaster->client && (self->teammaster->health <= 0 || self->teammaster->deadflag == DEAD_DEAD)))
+    {
+        tesla_remove_ownerdead(self);
+        return;
+    }
+
     if (gi.pointcontents(self->s.origin) & (CONTENTS_SLIME | CONTENTS_LAVA | CONTENTS_WATER))
     {
         tesla_blow(self);
@@ -1151,7 +1599,7 @@ static void tesla_activate(edict_t *self)
 
     trigger = G_Spawn();
     VectorCopy(self->s.origin, trigger->s.origin);
-    VectorSet(trigger->mins, -radius, -radius, self->mins[2]);
+    VectorSet(trigger->mins, -radius, -radius, -radius);
     VectorSet(trigger->maxs, radius, radius, radius);
     trigger->movetype = MOVETYPE_NONE;
     trigger->solid = SOLID_TRIGGER;
@@ -1160,7 +1608,8 @@ static void tesla_activate(edict_t *self)
     trigger->classname = "tesla trigger";
     gi.linkentity(trigger);
 
-    VectorClear(self->s.angles);
+    if (self->movetype != MOVETYPE_NONE)
+        VectorClear(self->s.angles);
     if (deathmatch->value)
         self->owner = NULL;
     self->teamchain = trigger;
@@ -1171,13 +1620,20 @@ static void tesla_activate(edict_t *self)
 
 static void tesla_think(edict_t *ent)
 {
+    if (!G_EntExists(ent->teammaster) || (ent->teammaster->client && (ent->teammaster->health <= 0 || ent->teammaster->deadflag == DEAD_DEAD)))
+    {
+        tesla_remove_ownerdead(ent);
+        return;
+    }
+
     if (gi.pointcontents(ent->s.origin) & (CONTENTS_SLIME | CONTENTS_LAVA))
     {
         tesla_remove(ent);
         return;
     }
 
-    VectorClear(ent->s.angles);
+    if (ent->movetype != MOVETYPE_NONE)
+        VectorClear(ent->s.angles);
 
     if (!ent->count)
     {
@@ -1230,6 +1686,9 @@ static void tesla_lava(edict_t *ent, edict_t *other, cplane_t *plane, csurface_t
         }
     }
 
+    if (deployable_stick(ent, other, plane, surf))
+        return;
+
     if (level.time < ent->timestamp)
         return;
     ent->timestamp = level.time + 0.25f;
@@ -1266,8 +1725,10 @@ void fire_tesla(edict_t *self, vec3_t start, vec3_t aimdir, int damage, int spee
     VectorSet(tesla->maxs, 12, 12, 20);
     tesla->s.modelindex = gi.modelindex("models/weapons/g_tesla/tris.md2");
     tesla->owner = self;
+    tesla->activator = self;
     tesla->teammaster = self;
     tesla->wait = level.time + TESLA_TIME_TO_LIVE;
+    tesla->delay = level.time + TESLA_ACTIVATE_TIME + TESLA_TIME_TO_LIVE;
     tesla->think = tesla_think;
     tesla->nextthink = level.time + TESLA_ACTIVATE_TIME;
     tesla->touch = tesla_lava;
@@ -1279,6 +1740,10 @@ void fire_tesla(edict_t *self, vec3_t start, vec3_t aimdir, int damage, int spee
     tesla->radius_dmg = 0;
     tesla->classname = "tesla";
     tesla->clipmask = MASK_SHOT | CONTENTS_SLIME | CONTENTS_LAVA;
+    tesla->mtype = M_TESLA;
 
     gi.linkentity(tesla);
+
+    if (self->client)
+        layout_add_tracked_entity(&self->client->layout, tesla);
 }

--- a/src/combat/weapons/g_weapon.c
+++ b/src/combat/weapons/g_weapon.c
@@ -175,6 +175,26 @@ qboolean fire_hit (edict_t *self, vec3_t aim, int damage, int kick)
 	return true;
 }
 
+qboolean fire_player_melee(edict_t *self, vec3_t start, vec3_t dir, int range, int damage, int kick, int mod)
+{
+	trace_t tr;
+	vec3_t end;
+
+	self->lastsound = level.framenum;
+
+	VectorNormalize(dir);
+	VectorMA(start, range, dir, end);
+	tr = gi.trace(start, NULL, NULL, end, self, MASK_SHOT);
+
+	if (!G_EntExists(tr.ent))
+		return false;
+	if (OnSameTeam(self, tr.ent))
+		return false;
+
+	T_Damage(tr.ent, self, self, dir, tr.endpos, tr.plane.normal, damage, kick, 0, mod);
+	return true;
+}
+
 
 /*
 =================

--- a/src/combat/weapons/p_weapon.c
+++ b/src/combat/weapons/p_weapon.c
@@ -16,6 +16,7 @@ void weapon_grenade_fire(edict_t* ent, qboolean held);
 
 // RAFAEL
 void weapon_trap_fire(edict_t* ent, qboolean held);
+static void weapon_tesla_fire(edict_t* ent, qboolean held);
 
 void P_ProjectSource(gclient_t* client, vec3_t point, vec3_t distance, vec3_t forward, vec3_t right, vec3_t result) {
 	vec3_t _distance;
@@ -909,6 +910,12 @@ GRENADE
 #define GRENADE_MAXSPEED        800
 #define GRENADE_INITIAL_SPEED    800
 #define GRENADE_ADDON_SPEED        40
+#define TRAP_TIMER              5.0
+#define TRAP_MINSPEED           500
+#define TRAP_MAXSPEED           900
+#define TESLA_TIMER             3.0
+#define TESLA_MINSPEED          600
+#define TESLA_MAXSPEED          900
 
 float get_weapon_grenade_speed(edict_t* ent)
 {
@@ -2576,6 +2583,66 @@ void Weapon_BFG(edict_t* ent) {
 //		Weapon_Generic (ent, 8, 32, 55, 58, pause_frames, fire_frames, weapon_bfg_fire);
 }
 
+static void weapon_disruptor_fire(edict_t *ent)
+{
+	vec3_t offset, start;
+	vec3_t forward, right;
+	vec3_t mins, maxs, end;
+	trace_t tr;
+	edict_t *enemy = NULL;
+	int damage = 90 + 4 * ent->myskills.weapons[WEAPON_BFG10K].mods[0].current_level;
+	int speed = 1200 + 20 * ent->myskills.weapons[WEAPON_BFG10K].mods[2].current_level;
+
+	if (is_quad)
+		damage *= 4;
+
+	AngleVectors(ent->client->v_angle, forward, right, NULL);
+	VectorScale(forward, -2, ent->client->kick_origin);
+	ent->client->kick_angles[0] = -1;
+
+	VectorSet(offset, 24, 8, ent->viewheight - 8);
+	P_ProjectSource(ent->client, ent->s.origin, offset, forward, right, start);
+	VectorSet(mins, -16, -16, -16);
+	VectorSet(maxs, 16, 16, 16);
+	VectorMA(start, 8192, forward, end);
+
+	tr = gi.trace(start, NULL, NULL, end, ent, MASK_SHOT);
+	if ((tr.ent != world) && G_ValidTarget(ent, tr.ent, false, true))
+		enemy = tr.ent;
+	else
+	{
+		tr = gi.trace(start, mins, maxs, end, ent, MASK_SHOT);
+		if ((tr.ent != world) && G_ValidTarget(ent, tr.ent, false, true))
+			enemy = tr.ent;
+	}
+
+	fire_disruptor(ent, start, forward, damage, speed, enemy);
+
+	gi.sound(ent, CHAN_WEAPON, gi.soundindex("weapons/disint2.wav"), 1, ATTN_NORM, 0);
+
+	if (ent->myskills.weapons[WEAPON_BFG10K].mods[4].current_level < 1)
+	{
+		gi.WriteByte(svc_muzzleflash);
+		gi.WriteShort(ent - g_edicts);
+		gi.WriteByte(MZ_TRACKER | is_silenced);
+		gi.multicast(ent->s.origin, MULTICAST_PVS);
+		PlayerNoise(ent, start, PNOISE_WEAPON);
+	}
+
+	if (!((int)dmflags->value & DF_INFINITE_AMMO))
+		ent->client->pers.inventory[ent->client->ammo_index] -= ent->client->pers.weapon->quantity;
+
+	ent->client->ps.gunframe++;
+}
+
+void Weapon_Disruptor(edict_t *ent)
+{
+	static int pause_frames[] = { 14, 19, 23, 0 };
+	static int fire_frames[] = { 5, 0 };
+
+	Weapon_Generic(ent, 4, 9, 29, 34, pause_frames, fire_frames, weapon_disruptor_fire);
+}
+
 void fire_flame(edict_t* self, vec3_t start, vec3_t dir, int speed, int damage);
 
 void Flamethrower_Fire(edict_t* ent) {
@@ -2789,22 +2856,39 @@ void Weapon_Phalanx(edict_t *ent)
 
 void weapon_trap_fire(edict_t *ent, qboolean held)
 {
-    vec3_t offset, forward, right, start;
+    vec3_t offset, forward, right, start, angles;
     int damage = 125 + 4 * ent->myskills.weapons[WEAPON_TRAP].mods[0].current_level;
     float timer;
     int speed;
+    int min_speed;
+    int max_speed;
     float radius = damage + 40 + 2 * ent->myskills.weapons[WEAPON_TRAP].mods[1].current_level;
 
     if (is_quad)
         damage *= 4;
 
-    VectorSet(offset, 8, 8, ent->viewheight - 8);
-    AngleVectors(ent->client->v_angle, forward, right, NULL);
+    VectorCopy(ent->client->v_angle, angles);
+    if (angles[PITCH] < -62.5f)
+        angles[PITCH] = -62.5f;
+
+    VectorSet(offset, 8, 0, ent->viewheight - 8);
+    AngleVectors(angles, forward, right, NULL);
     P_ProjectSource(ent->client, ent->s.origin, offset, forward, right, start);
 
     timer = ent->client->grenade_time - level.time;
-    speed = GRENADE_MINSPEED + (GRENADE_TIMER - timer) * ((GRENADE_MAXSPEED - GRENADE_MINSPEED) / GRENADE_TIMER);
-    speed += 10 * ent->myskills.weapons[WEAPON_TRAP].mods[2].current_level;
+    if (timer < 0)
+        timer = 0;
+
+    min_speed = TRAP_MINSPEED + 10 * ent->myskills.weapons[WEAPON_TRAP].mods[2].current_level;
+    max_speed = TRAP_MAXSPEED + 10 * ent->myskills.weapons[WEAPON_TRAP].mods[2].current_level;
+
+    if (ent->health <= 0)
+        speed = min_speed;
+    else
+        speed = min_speed + (TRAP_TIMER - timer) * ((max_speed - min_speed) / TRAP_TIMER);
+
+    if (speed > max_speed)
+        speed = max_speed;
 
     fire_trap(ent, start, forward, damage, speed, timer, radius, held);
 
@@ -2871,7 +2955,7 @@ void Weapon_Trap(edict_t *ent)
         {
             if (!ent->client->grenade_time)
             {
-                ent->client->grenade_time = level.time + GRENADE_TIMER + 0.2;
+                ent->client->grenade_time = level.time + TRAP_TIMER + 0.2;
                 ent->client->weapon_sound = gi.soundindex("weapons/traploop.wav");
             }
 
@@ -2923,9 +3007,17 @@ void Weapon_Trap(edict_t *ent)
 static void weapon_etf_rifle_fire(edict_t *ent)
 {
     vec3_t forward, right, angles, start, offset;
+    int i;
     int damage = 10 + ent->myskills.weapons[WEAPON_ETFRIFLE].mods[0].current_level;
     int kick = 3;
     int speed = 750 + 15 * ent->myskills.weapons[WEAPON_ETFRIFLE].mods[2].current_level;
+    vec3_t kick_origin, kick_angles;
+
+    if (!(ent->client->buttons & BUTTON_ATTACK))
+    {
+        ent->client->ps.gunframe = 8;
+        return;
+    }
 
     if (ent->client->pers.inventory[ent->client->ammo_index] < ent->client->pers.weapon->quantity)
     {
@@ -2948,7 +3040,15 @@ static void weapon_etf_rifle_fire(edict_t *ent)
         kick *= 4;
     }
 
-    VectorAdd(ent->client->v_angle, ent->client->kick_angles, angles);
+    for (i = 0; i < 3; i++)
+    {
+        kick_origin[i] = crandom() * 0.85f;
+        kick_angles[i] = crandom() * 0.85f;
+    }
+
+    VectorCopy(kick_origin, ent->client->kick_origin);
+    VectorCopy(kick_angles, ent->client->kick_angles);
+    VectorAdd(ent->client->v_angle, kick_angles, angles);
     AngleVectors(angles, forward, right, NULL);
 
     if (ent->client->ps.gunframe == 6)
@@ -2965,14 +3065,23 @@ static void weapon_etf_rifle_fire(edict_t *ent)
     gi.multicast(ent->s.origin, MULTICAST_PVS);
 
     PlayerNoise(ent, start, PNOISE_WEAPON);
-    ent->client->ps.gunframe++;
+    ent->client->vrr.gun_fire_time = level.time + 0.1;
+    if (ent->client->buttons & BUTTON_ATTACK)
+    {
+        if (ent->client->ps.gunframe == 6)
+            ent->client->ps.gunframe = 7;
+        else
+            ent->client->ps.gunframe = 6;
+    }
+    else
+        ent->client->ps.gunframe = 8;
     ent->client->pers.inventory[ent->client->ammo_index] -= ent->client->pers.weapon->quantity;
 }
 
 void Weapon_ETF_Rifle(edict_t *ent)
 {
     static int pause_frames[] = {18, 28, 0};
-    static int fire_frames[] = {6, 7, 0};
+    static int fire_frames[] = {5, 6, 7, 0};
 
     if (ent->client->weaponstate == WEAPON_FIRING)
     {
@@ -2981,8 +3090,6 @@ void Weapon_ETF_Rifle(edict_t *ent)
     }
 
     Weapon_Generic(ent, 4, 7, 37, 41, pause_frames, fire_frames, weapon_etf_rifle_fire);
-    if (ent->client->ps.gunframe == 8 && (ent->client->buttons & BUTTON_ATTACK))
-        ent->client->ps.gunframe = 6;
 }
 
 #define HEATBEAM_DM_DMG 15
@@ -2994,15 +3101,27 @@ static void PlasmaBeam_Fire(edict_t *ent)
     vec3_t offset;
     int damage;
     int kick;
+    qboolean firing;
+    qboolean has_ammo;
 
-    if (ent->client->pers.inventory[ent->client->ammo_index] < ent->client->pers.weapon->quantity)
+    firing = (ent->client->buttons & BUTTON_ATTACK) != 0;
+    has_ammo = ent->client->pers.inventory[ent->client->ammo_index] >= ent->client->pers.weapon->quantity;
+
+    if (!firing || !has_ammo)
     {
-        if (level.time >= ent->pain_debounce_time)
+        ent->client->ps.gunframe = 13;
+        ent->client->weapon_sound = 0;
+        ent->client->ps.gunskin = 0;
+
+        if (firing && !has_ammo)
         {
-            gi.sound(ent, CHAN_VOICE, gi.soundindex("weapons/noammo.wav"), 1, ATTN_NORM, 0);
-            ent->pain_debounce_time = level.time + 1;
+            if (level.time >= ent->pain_debounce_time)
+            {
+                gi.sound(ent, CHAN_VOICE, gi.soundindex("weapons/noammo.wav"), 1, ATTN_NORM, 0);
+                ent->pain_debounce_time = level.time + 1;
+            }
+            NoAmmoWeaponChange(ent);
         }
-        NoAmmoWeaponChange(ent);
         return;
     }
 
@@ -3016,8 +3135,16 @@ static void PlasmaBeam_Fire(edict_t *ent)
     else
         kick = 30;
 
-    ent->client->ps.gunframe++;
-    ent->client->ps.gunindex = gi.modelindex("models/weapons/v_beamer2/tris.md2");
+    if (ent->client->ps.gunframe > 12)
+        ent->client->ps.gunframe = 8;
+    else
+        ent->client->ps.gunframe++;
+
+    if (ent->client->ps.gunframe == 12)
+        ent->client->ps.gunframe = 8;
+
+    ent->client->weapon_sound = gi.soundindex("weapons/bfg__l1a.wav");
+    ent->client->ps.gunskin = 1;
 
     if (is_quad)
     {
@@ -3062,35 +3189,13 @@ void Weapon_Heatbeam(edict_t *ent)
     static int pause_frames[] = {35, 0};
     static int fire_frames[] = {9, 10, 11, 12, 0};
 
-    if (ent->client->weaponstate == WEAPON_FIRING)
+    if (ent->client->weaponstate != WEAPON_FIRING)
     {
-        ent->client->weapon_sound = gi.soundindex("weapons/bfg__l1a.wav");
-        if ((ent->client->pers.inventory[ent->client->ammo_index] >= ent->client->pers.weapon->quantity)
-            && ((ent->client->buttons) & BUTTON_ATTACK))
-        {
-            if (ent->client->ps.gunframe >= 13)
-            {
-                ent->client->ps.gunframe = 9;
-                ent->client->ps.gunindex = gi.modelindex("models/weapons/v_beamer2/tris.md2");
-            }
-            else
-            {
-                ent->client->ps.gunindex = gi.modelindex("models/weapons/v_beamer2/tris.md2");
-            }
-        }
-        else
-        {
-            ent->client->ps.gunframe = 13;
-            ent->client->ps.gunindex = gi.modelindex("models/weapons/v_beamer/tris.md2");
-        }
-    }
-    else
-    {
-        ent->client->ps.gunindex = gi.modelindex("models/weapons/v_beamer/tris.md2");
         ent->client->weapon_sound = 0;
+        ent->client->ps.gunskin = 0;
     }
 
-    Weapon_Generic(ent, 8, 12, 39, 44, pause_frames, fire_frames, PlasmaBeam_Fire);
+    Weapon_Generic(ent, 8, 12, 42, 47, pause_frames, fire_frames, PlasmaBeam_Fire);
 }
 
 static void weapon_proxlauncher_fire(edict_t *ent)
@@ -3133,44 +3238,105 @@ void Weapon_ProxLauncher(edict_t *ent)
 
 static void weapon_chainfist_fire(edict_t *ent)
 {
-    vec3_t aim;
+    vec3_t start, dir;
+    vec3_t forward, right;
+    int frame = ent->client->ps.gunframe;
     int damage = 30 + 2 * ent->myskills.weapons[WEAPON_CHAINFIST].mods[0].current_level;
     int kick = 80;
+
+    if (!(ent->client->buttons & BUTTON_ATTACK))
+    {
+        if ((frame == 13) || (frame == 23) || (frame >= 32))
+        {
+            ent->client->weapon_sound = gi.soundindex("weapons/sawidle.wav");
+            ent->client->ps.gunframe = 33;
+            return;
+        }
+    }
 
     if (is_quad)
         damage *= 4;
 
-    VectorSet(aim, 64, 0, 0);
-    if (fire_hit(ent, aim, damage, kick))
-        gi.sound(ent, CHAN_WEAPON, gi.soundindex("weapons/sawhit.wav"), 1, ATTN_NORM, 0);
+    AngleVectors(ent->client->v_angle, forward, right, NULL);
+    VectorSet(start, 0, 0, ent->viewheight - 4);
+    P_ProjectSource(ent->client, ent->s.origin, start, forward, right, start);
+    VectorCopy(forward, dir);
 
-    ent->client->ps.gunframe++;
+    if (ent->client->buttons & BUTTON_ATTACK)
+    {
+        if (fire_player_melee(ent, start, dir, 32, damage, kick, MOD_HIT))
+            gi.sound(ent, CHAN_WEAPON, gi.soundindex("weapons/sawhit.wav"), 1, ATTN_NORM, 0);
+    }
+
     PlayerNoise(ent, ent->s.origin, PNOISE_WEAPON);
+    ent->client->ps.gunframe++;
+    ent->client->vrr.gun_fire_time = level.time + 0.12;
+    ent->client->weapon_sound = gi.soundindex("weapons/sawhit.wav");
+
+    if (ent->client->buttons & BUTTON_ATTACK)
+    {
+        if (ent->client->ps.gunframe >= 32)
+            ent->client->ps.gunframe = 7;
+    }
 }
 
 void Weapon_ChainFist(edict_t *ent)
 {
     static int pause_frames[] = {0};
-    static int fire_frames[] = {8, 9, 16, 17, 18, 30, 31, 0};
+    static int fire_frames[] = {
+        5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16,
+        17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28,
+        29, 30, 31, 32, 0
+    };
 
-    ent->client->weapon_sound = 0;
+    if (ent->client->weaponstate == WEAPON_DROPPING)
+        ent->client->weapon_sound = 0;
+    else if ((ent->client->weaponstate == WEAPON_FIRING) && (ent->client->buttons & BUTTON_ATTACK))
+        ent->client->weapon_sound = gi.soundindex("weapons/sawhit.wav");
+    else
+        ent->client->weapon_sound = gi.soundindex("weapons/sawidle.wav");
 
     Weapon_Generic(ent, 4, 32, 57, 60, pause_frames, fire_frames, weapon_chainfist_fire);
 }
 
-static void weapon_tesla_fire(edict_t *ent)
+static void weapon_tesla_fire(edict_t *ent, qboolean held)
 {
-    vec3_t offset, start, forward, right;
+    vec3_t offset, start, forward, right, angles;
     int damage = 3 + ent->myskills.weapons[WEAPON_TESLA].mods[0].current_level;
     float radius = 128 + 4 * ent->myskills.weapons[WEAPON_TESLA].mods[1].current_level;
-    int speed = 500 + 15 * ent->myskills.weapons[WEAPON_TESLA].mods[2].current_level;
+    float timer;
+    int speed;
+    int min_speed;
+    int max_speed;
+
+    (void) held;
 
     if (is_quad)
         damage *= 4;
 
-    VectorSet(offset, 8, 8, ent->viewheight - 8);
-    AngleVectors(ent->client->v_angle, forward, right, NULL);
+    VectorCopy(ent->client->v_angle, angles);
+    if (angles[PITCH] < -62.5f)
+        angles[PITCH] = -62.5f;
+
+    VectorSet(offset, 0, 0, ent->viewheight - 22);
+    AngleVectors(angles, forward, right, NULL);
     P_ProjectSource(ent->client, ent->s.origin, offset, forward, right, start);
+
+    timer = ent->client->grenade_time - level.time;
+    if (timer < 0)
+        timer = 0;
+
+    min_speed = TESLA_MINSPEED + 15 * ent->myskills.weapons[WEAPON_TESLA].mods[2].current_level;
+    max_speed = TESLA_MAXSPEED + 15 * ent->myskills.weapons[WEAPON_TESLA].mods[2].current_level;
+
+    if (ent->health <= 0)
+        speed = min_speed;
+    else
+        speed = min_speed + (TESLA_TIMER - timer) * ((max_speed - min_speed) / TESLA_TIMER);
+
+    if (speed > max_speed)
+        speed = max_speed;
+
     fire_tesla(ent, start, forward, damage, speed, radius);
 
     gi.WriteByte(svc_muzzleflash);
@@ -3181,14 +3347,81 @@ static void weapon_tesla_fire(edict_t *ent)
 
     if (!((int)dmflags->value & DF_INFINITE_AMMO))
         ent->client->pers.inventory[ent->client->ammo_index] -= ent->client->pers.weapon->quantity;
-
-    ent->client->ps.gunframe++;
 }
 
 void Weapon_Tesla(edict_t *ent)
 {
-    static int pause_frames[] = {34, 51, 59, 0};
-    static int fire_frames[] = {6, 0};
+    if ((ent->client->newweapon) && (ent->client->weaponstate == WEAPON_READY))
+    {
+        ChangeWeapon(ent);
+        return;
+    }
 
-    Weapon_Generic(ent, 5, 16, 59, 64, pause_frames, fire_frames, weapon_tesla_fire);
+    if (ent->client->weaponstate == WEAPON_ACTIVATING)
+    {
+        ent->client->weaponstate = WEAPON_READY;
+        ent->client->ps.gunframe = 9;
+        return;
+    }
+
+    if (ent->client->weaponstate == WEAPON_READY)
+    {
+        if (((ent->client->latched_buttons | ent->client->buttons) & BUTTON_ATTACK))
+        {
+            ent->client->latched_buttons &= ~BUTTON_ATTACK;
+            if (ent->client->pers.inventory[ent->client->ammo_index])
+            {
+                ent->client->ps.gunframe = 1;
+                ent->client->weaponstate = WEAPON_FIRING;
+                ent->client->grenade_time = 0;
+            }
+            else
+            {
+                if (level.time >= ent->pain_debounce_time)
+                {
+                    gi.sound(ent, CHAN_VOICE, gi.soundindex("weapons/noammo.wav"), 1, ATTN_NORM, 0);
+                    ent->pain_debounce_time = level.time + 1;
+                }
+                NoAmmoWeaponChange(ent);
+            }
+            return;
+        }
+
+        if (ent->client->ps.gunframe == 21)
+        {
+            if (randomMT() & 15)
+                return;
+        }
+
+        if (++ent->client->ps.gunframe > 32)
+            ent->client->ps.gunframe = 9;
+        return;
+    }
+
+    if (ent->client->weaponstate == WEAPON_FIRING)
+    {
+        if (ent->client->ps.gunframe == 1)
+        {
+            if (!ent->client->grenade_time)
+                ent->client->grenade_time = level.time + TESLA_TIMER + 0.2;
+
+            if (ent->client->buttons & BUTTON_ATTACK)
+                return;
+        }
+
+        if (ent->client->ps.gunframe == 2)
+        {
+            weapon_tesla_fire(ent, false);
+            if (ent->client->pers.inventory[ent->client->ammo_index] == 0)
+                NoAmmoWeaponChange(ent);
+        }
+
+        ent->client->ps.gunframe++;
+
+        if (ent->client->ps.gunframe == 9)
+        {
+            ent->client->grenade_time = 0;
+            ent->client->weaponstate = WEAPON_READY;
+        }
+    }
 }

--- a/src/g_local.h
+++ b/src/g_local.h
@@ -749,6 +749,7 @@ extern int	cell_index;
 extern int	magslug_index;
 extern int	trap_index;
 extern int	tesla_index;
+extern int	disruptor_index;
 
 //weapons
 extern int sword_index;
@@ -906,6 +907,7 @@ extern int skullindex;
 #define MOD_SENTRY_BEAM		102
 #define MOD_EXPLODING_BARREL	103
 #define MOD_SHRAPNEL			104
+#define MOD_TRACKER			105
 //K03 End
 #define MOD_FRIENDLY_FIRE	0x8000000
 #define MOD_FMEDICPACK		150
@@ -1366,6 +1368,7 @@ void Weapon_Heatbeam (edict_t *ent);
 void Weapon_ProxLauncher (edict_t *ent);
 void Weapon_ChainFist (edict_t *ent);
 void Weapon_Tesla (edict_t *ent);
+void Weapon_Disruptor (edict_t *ent);
 
 //K03 Begin
 void Weapon_Sword(edict_t *ent);
@@ -1535,6 +1538,8 @@ enum mtype_t {
     M_BARREL = 132,
     M_ARMOR = 133,
     M_FIREWALL = 134,
+    M_TRAP = 135,
+    M_TESLA = 136,
     P_TANK = 200,
     MORPH_MUTANT = 400,
     MORPH_CACODEMON = 401,
@@ -1693,6 +1698,7 @@ qboolean vrx_is_in_target_list(edict_t *ent);
 void ThrowDebris(edict_t *self, char *modelname, float speed, vec3_t origin);
 
 qboolean fire_hit(edict_t *self, vec3_t aim, int damage, int kick);
+qboolean fire_player_melee(edict_t *self, vec3_t start, vec3_t dir, int range, int damage, int kick, int mod);
 
 void fire_bullet(edict_t *self, vec3_t start, vec3_t aimdir, float damage, int kick, int hspread, int vspread, int mod);
 
@@ -1714,6 +1720,7 @@ void fire_rocket(edict_t *self, vec3_t start, vec3_t dir, int damage, int speed,
 void fire_rail(edict_t *self, vec3_t start, vec3_t aimdir, int damage, int kick);
 
 void fire_bfg(edict_t *self, vec3_t start, vec3_t dir, int damage, int speed, float damage_radius);
+void fire_disruptor(edict_t *self, vec3_t start, vec3_t dir, int damage, int speed, edict_t *enemy);
 
 // RAFAEL
 void fire_ionripper (edict_t *self, vec3_t start, vec3_t aimdir, int damage, int speed, int effect);
@@ -1724,6 +1731,7 @@ void fire_plasma (edict_t *self, vec3_t start, vec3_t dir, int damage, int speed
 void fire_prox (edict_t *self, vec3_t start, vec3_t aimdir, int damage, int speed, float damage_radius);
 void fire_tesla (edict_t *self, vec3_t start, vec3_t aimdir, int damage, int speed, float damage_radius);
 void fire_trap (edict_t *self, vec3_t start, vec3_t aimdir, int damage, int speed, float timer, float damage_radius, qboolean held);
+void RemoveOwnedDeployables(edict_t *owner);
 void fire_smartrocket (edict_t *self, edict_t *target, vec3_t start, vec3_t dir, int damage, int speed, int turn_speed, float damage_radius, int radius_damage);
 
 void fire_20mm(edict_t* self, vec3_t start, vec3_t aimdir, int damage, int kick, float range);
@@ -1893,6 +1901,7 @@ typedef struct {
 	int			max_magslug;
 	int			max_trap;
 	int			max_tesla;
+	int			max_disruptor;
 
     gitem_t *weapon;
     gitem_t *lastweapon;

--- a/src/menus/armory.c
+++ b/src/menus/armory.c
@@ -214,7 +214,7 @@ void Cmd_Armory_f(edict_t *ent, int selection)
 		return;
 
 	//What is the price/qty of the item?
-	if (((selection < 11) && (selection > 0)) || (selection >= 31 && selection <= 38))
+	if (((selection < 11) && (selection > 0)) || (selection >= 31 && selection <= 39))
     {
 		price = ARMORY_PRICE_WEAPON;
         is_weapon = true;
@@ -243,6 +243,7 @@ void Cmd_Armory_f(edict_t *ent, int selection)
         case 36:    item = FindItem("Prox Launcher");  break;
         case 37:    item = FindItem("Chainfist");      break;
         case 38:    item = FindItem("Tesla");          break;
+        case 39:    item = FindItem("Disruptor");      break;
 
 		//ammo
 		case 11:
@@ -381,7 +382,7 @@ void Cmd_Armory_f(edict_t *ent, int selection)
 
 		// New missionpack weapons can require ammo types players may not be carrying.
 		// Grant the minimum needed ammo and auto-select the weapon for immediate use.
-		if (selection >= 31 && selection <= 38)
+		if (selection >= 31 && selection <= 39)
 		{
 			if (item->ammo)
 			{

--- a/src/menus/v_menu.c
+++ b/src/menus/v_menu.c
@@ -392,7 +392,7 @@ void respawnmenu_handler (edict_t *ent, int option)
 		return;
 	}
 
-	if (option < 1 || option > 21)
+	if (option < 1 || option > 22)
 		return;
 
 	ent->myskills.respawn_weapon = option;
@@ -424,6 +424,7 @@ char *GetRespawnString (edict_t *ent)
 	case 19: return "Prox Launcher";
 	case 20: return "Chainfist";
 	case 21: return "Tesla";
+	case 22: return "Disruptor";
 	default: return "Unknown";
 	}
 }
@@ -454,6 +455,7 @@ static const respawn_menu_item_t respawn_items[] = {
 	{"Prox Launcher", 19},
 	{"Chainfist", 20},
 	{"Tesla", 21},
+	{"Disruptor", 22},
 	{"Blaster", 13}
 };
 

--- a/src/quake2/g_cmds.c
+++ b/src/quake2/g_cmds.c
@@ -888,14 +888,75 @@ int GetSlot(gitem_t *it)
 	else if(it == FindItem("shotgun")) slot = 2;
 	else if(it == FindItem("super shotgun")) slot = 3;
 	else if(it == FindItem("Machinegun")) slot = 4;
+	else if(it == FindItem("ETF Rifle")) slot = 4;
 	else if(it == FindItem("chaingun"))	slot = 5;
 	else if(it == FindItem("grenade launcher")) slot = 6;
+	else if(it == FindItem("Prox Launcher")) slot = 6;
 	else if(it == FindItem("rocket launcher")) slot = 7;
 	else if(it == FindItem("hyperblaster")) slot = 8;
+	else if(it == FindItem("Ionripper")) slot = 8;
+	else if(it == FindItem("Plasma Beam")) slot = 8;
 	else if(it == FindItem("railgun")) slot = 9;
+	else if(it == FindItem("Phalanx")) slot = 9;
 	else if(it == FindItem("bfg10k")) slot = 10;
+	else if(it == FindItem("Disruptor")) slot = 10;
     else if(it == FindItem("flamethrower")) slot = 10;
 	return (slot);
+}
+
+static qboolean Cmd_PlayerHasWeapon(edict_t *ent, gitem_t *item)
+{
+	return item && ent->client->pers.inventory[ITEM_INDEX(item)];
+}
+
+static gitem_t *Cmd_CycleWeaponGroup(edict_t *ent, gitem_t *requested, const char **names, int count)
+{
+	gitem_t *current;
+	int requested_index = -1;
+	int current_index = -1;
+	int i;
+
+	if (!requested)
+		return NULL;
+
+	current = ent->client->pers.weapon;
+
+	for (i = 0; i < count; i++)
+	{
+		gitem_t *item = FindItem((char *) names[i]);
+
+		if (item == requested)
+			requested_index = i;
+		if (item == current)
+			current_index = i;
+	}
+
+	if (requested_index < 0)
+		return requested;
+
+	if (current_index >= 0)
+	{
+		for (i = 1; i <= count; i++)
+		{
+			gitem_t *item = FindItem((char *) names[(current_index + i) % count]);
+
+			if (Cmd_PlayerHasWeapon(ent, item))
+				return item;
+		}
+	}
+
+	if (Cmd_PlayerHasWeapon(ent, requested))
+		return requested;
+
+	for (i = 1; i < count; i++)
+	{
+		gitem_t *item = FindItem((char *) names[(requested_index + i) % count]);
+
+		if (Cmd_PlayerHasWeapon(ent, item))
+			return item;
+	}
+
+	return requested;
 }
 
 qboolean Cmd_UseMorphWeapons_f (edict_t *ent, char *s)
@@ -1000,6 +1061,13 @@ void Cmd_Use_f (edict_t *ent)
 	const int			weapMode=ent->client->weapon_mode;
 	gitem_t		*it;
 	char		*s;
+	static const char *blaster_cycle[] = {"Blaster", "Sword", "Chainfist"};
+	static const char *machinegun_cycle[] = {"Machinegun", "ETF Rifle"};
+	static const char *grenade_cycle[] = {"Grenade Launcher", "Prox Launcher"};
+	static const char *throwable_cycle[] = {"Grenades", "Tesla", "Trap"};
+	static const char *hyper_cycle[] = {"HyperBlaster", "Ionripper", "Plasma Beam"};
+	static const char *rail_cycle[] = {"Railgun", "Phalanx"};
+	static const char *bfg_cycle[] = {"BFG10K", "Disruptor"};
 
 	//K03 Begin
 	int		slot;
@@ -1055,10 +1123,13 @@ void Cmd_Use_f (edict_t *ent)
     if ((ent->myskills.class_num == CLASS_KNIGHT) && (slot > 0) && (slot < 11))
         return;
 
-    if (slot == 1 && ent->client->pers.weapon == FindItem("Blaster"))
-        it = FindItem("Sword");
-    else if (slot == 1 && ent->client->pers.weapon == FindItem("Sword"))
-        it = FindItem("Blaster");
+	it = Cmd_CycleWeaponGroup(ent, it, blaster_cycle, sizeof(blaster_cycle) / sizeof(blaster_cycle[0]));
+	it = Cmd_CycleWeaponGroup(ent, it, machinegun_cycle, sizeof(machinegun_cycle) / sizeof(machinegun_cycle[0]));
+	it = Cmd_CycleWeaponGroup(ent, it, grenade_cycle, sizeof(grenade_cycle) / sizeof(grenade_cycle[0]));
+	it = Cmd_CycleWeaponGroup(ent, it, throwable_cycle, sizeof(throwable_cycle) / sizeof(throwable_cycle[0]));
+	it = Cmd_CycleWeaponGroup(ent, it, hyper_cycle, sizeof(hyper_cycle) / sizeof(hyper_cycle[0]));
+	it = Cmd_CycleWeaponGroup(ent, it, rail_cycle, sizeof(rail_cycle) / sizeof(rail_cycle[0]));
+	it = Cmd_CycleWeaponGroup(ent, it, bfg_cycle, sizeof(bfg_cycle) / sizeof(bfg_cycle[0]));
     //K03 End
     index = ITEM_INDEX(it);
     if (!ent->client->pers.inventory[index] && (it != FindItem("tball self")))//K03 tball self exception
@@ -1506,6 +1577,7 @@ void Cmd_Kill_f (edict_t *ent)
 	ent->health = 0;
 	meansOfDeath = MOD_SUICIDE;
 	player_die (ent, ent, ent, 100000, vec3_origin);
+	RemoveOwnedDeployables(ent);
 	// don't even bother waiting for death frames
 	ent->deadflag = DEAD_DEAD;
 	respawn (ent);

--- a/src/quake2/g_layout.c
+++ b/src/quake2/g_layout.c
@@ -348,6 +348,14 @@ sidebar_entry_t layout_add_entity_info(sidebar_t* sidebar, edict_t* ent)
 		name = lva("magmine");
 		data = lva("+%d/%dc", ent->health, ent->light_level);
 		break;
+	case M_TRAP:
+		name = lva("trap");
+		data = lva("%ds", (int)ceil(ent->timestamp - level.time));
+		break;
+	case M_TESLA:
+		name = lva("tesla");
+		data = lva("+%d %ds", ent->health, (int)ceil(ent->delay - level.time));
+		break;
 	case TOTEM_FIRE:
 	case TOTEM_WATER:
 	case TOTEM_AIR:

--- a/src/quake2/g_utils.c
+++ b/src/quake2/g_utils.c
@@ -1146,6 +1146,7 @@ int Get_KindWeapon (gitem_t	*it)
 	else if(it->weaponthink == Weapon_HyperBlaster) return WEAP_HYPERBLASTER;
 	else if(it->weaponthink == Weapon_Railgun)		return WEAP_RAILGUN;
 	else if(it->weaponthink == Weapon_BFG)			return WEAP_BFG;
+	else if(it->weaponthink == Weapon_Disruptor)	return WEAP_BFG;
 	else if(it->weaponthink == Weapon_20mm)		return WEAP_20MM;
 	else if(it->weaponthink == Weapon_Sword)		return WEAP_SWORD;
 	else if(it->weaponthink == Weapon_Ionripper)	return WEAP_HYPERBLASTER;

--- a/src/quake2/p_client.c
+++ b/src/quake2/p_client.c
@@ -556,6 +556,10 @@ void ClientObituary (edict_t *self, edict_t *inflictor, edict_t *attacker)
 				message = "couldn't hide from";
 				message2 = "'s BFG";
 				break;
+			case MOD_TRACKER:
+				message = "was disrupted by";
+				message2 = "'s disruptor";
+				break;
 			case MOD_HANDGRENADE:
 				message = "tries to hatch";
 				message2 = "'s handgrenade";
@@ -1135,6 +1139,7 @@ void InitClientPersistant (gclient_t *client)
 	client->pers.max_magslug	= 50;
 	client->pers.max_trap		= 5;
 	client->pers.max_tesla		= 5;
+	client->pers.max_disruptor	= 12;
 
 	//K03 Begin
 	client->pers.max_powercubes = 200;

--- a/src/server/misc_stuff.c
+++ b/src/server/misc_stuff.c
@@ -348,6 +348,14 @@ void Check_full(edict_t *ent)
 		if (ent->client->pers.inventory[index] > ent->client->pers.max_slugs)
 			ent->client->pers.inventory[index] = ent->client->pers.max_slugs;
 	}
+
+	item = FindItem("Rounds");
+	if (item)
+	{
+		index = ITEM_INDEX(item);
+		if (ent->client->pers.inventory[index] > ent->client->pers.max_disruptor)
+			ent->client->pers.inventory[index] = ent->client->pers.max_disruptor;
+	}
 }
 
 float entdist(const edict_t *ent1, const edict_t *ent2)


### PR DESCRIPTION
Changes included:

** Potentially important change in player_die: ? **
- added cleanup on player_die function: RemoveOwnedDeployables(ent)
I'm in doubt here since typing 'kill' while having traps/teslas would not destroy them, I think it's related to the instant respawning.

- added rotative weapon selection according to binding
- added Disruptor weapon and vrxrespawn/armory support their ammo ( rounds )
- ETF Rifle has a bit of less delay now when starting the +attack
- fixed chainfist so it now deals damage
- teslas/traps would respect teammates
- teslas/traps can now stick to walls/ceilings ( traps are not using EF_TRAP because of this now )
- trap pull behavior got modified so it works more like a magmine
- added HUD relay support for teslas/traps, showing their time to expire
- fixed plasmabeam's weapon model disappearing while shooting
- modified trap explosion behavior when pulling a large monster without dealing direct damage ( now does a grenade explosion so it hurts a bit, instead of the becomeexplosion1 )

Note:
lightning ray behavior of plasma beam remains the same for now, unsure why.